### PR TITLE
Inline OCR helpers

### DIFF
--- a/multimodal_cli.py
+++ b/multimodal_cli.py
@@ -23,6 +23,7 @@ import math
 import shutil
 from mimetypes import guess_type
 from io import BytesIO
+
 # import wave
 
 # ───────── third-party ─────────
@@ -30,6 +31,7 @@ from openai import OpenAI
 import requests
 import pytesseract
 from PIL import Image, ImageEnhance
+
 # import sounddevice as sd
 # import numpy as np
 from mgrs import MGRS
@@ -48,6 +50,7 @@ client = OpenAI(api_key=OPENAI_API_KEY)
 if shutil.which("tesseract") is None:
     print("⚠️  Tesseract not in PATH – OCR fallback will fail", file=sys.stderr)
 
+
 # ───────── retry utility ─────────
 def retry(fn, *args, retries=3, **kwargs):
     for i in range(1, retries + 1):
@@ -56,9 +59,10 @@ def retry(fn, *args, retries=3, **kwargs):
         except Exception as e:
             if i == retries:
                 raise
-            back = 2 ** i + random.random()
+            back = 2**i + random.random()
             print(f"[Retry {i}/{retries}] {fn.__name__}: {e} → {back:.1f}s")
             time.sleep(back)
+
 
 # ───────── helpers ─────────
 def to_data_url(path: str) -> str:
@@ -67,19 +71,24 @@ def to_data_url(path: str) -> str:
         b64 = base64.b64encode(f.read()).decode()
     return f"data:{mime or 'application/octet-stream'};base64,{b64}"
 
-def _haversine(a1,a2,b1,b2):
-    R=6371
-    dlat=math.radians(b1-a1)
-    dlon=math.radians(b2-a2)
-    h=(math.sin(dlat/2)**2 +
-       math.cos(math.radians(a1))*
-       math.cos(math.radians(b1))*
-       math.sin(dlon/2)**2)
-    return R*2*math.asin(math.sqrt(h))
+
+def _haversine(a1, a2, b1, b2):
+    R = 6371
+    dlat = math.radians(b1 - a1)
+    dlon = math.radians(b2 - a2)
+    h = (
+        math.sin(dlat / 2) ** 2
+        + math.cos(math.radians(a1))
+        * math.cos(math.radians(b1))
+        * math.sin(dlon / 2) ** 2
+    )
+    return R * 2 * math.asin(math.sqrt(h))
+
 
 # ───────── OCR pipeline ─────────
 def preprocess(img):
     return ImageEnhance.Contrast(img.convert("L")).enhance(2.0)
+
 
 def tesseract_ocr(path):
     try:
@@ -88,10 +97,10 @@ def tesseract_ocr(path):
         print("❌  Cannot open image:", e, file=sys.stderr)
         return ""
     out = ""
-    for angle in (0,90,180,270):
+    for angle in (0, 90, 180, 270):
         txt = pytesseract.image_to_string(
             preprocess(base.rotate(angle, expand=True)),
-            config="--psm 6 -c tessedit_char_whitelist=0123456789.,NSEW "
+            config="--psm 6 -c tessedit_char_whitelist=0123456789.,NSEW ",
         ).strip()
         print(f"\n[Tesseract {angle}°]\n{txt or '[no text]'}")
         out = txt or out
@@ -100,78 +109,93 @@ def tesseract_ocr(path):
                 return txt
     return out
 
+
 def gpt_vision_ocr(path):
     resp = retry(
-        client.responses.create,
+        client.chat.completions.create,
         model="gpt-4o-mini",
-        input=[{
-            "role": "user",
-            "content": [
-                {"type":"input_text", "text":
-                 "Leia drooni ekraanil kuvatud GPS-koordinaadid ja vasta ainult kümnend‑kraadides kujul, "
-                 "näiteks: 57.927336° N, 26.747699° E"},
-                {"type":"input_image","image_url":to_data_url(path)}
-            ]
-        }],
-        timeout=60
+        input=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": "Leia drooni ekraanil kuvatud GPS-koordinaadid ja vasta ainult kümnend‑kraadides kujul, "
+                        "näiteks: 57.927336° N, 26.747699° E",
+                    },
+                    {"type": "input_image", "image_url": to_data_url(path)},
+                ],
+            }
+        ],
+        timeout=60,
     )
     return resp.output_text.strip()
+
 
 # ───────── coordinate utils ─────────
 def parse_coords(txt):
     if not txt:
         return None
-    t = txt.upper().replace("°","")
+    t = txt.upper().replace("°", "")
     lat = lon = None
     m1 = re.search(r"(-?\d+\.\d+)\s*([NS])", t)
     m2 = re.search(r"(-?\d+\.\d+)\s*([EW])", t)
     if m1 and m2:
-        lat = float(m1.group(1)) * (1 if m1.group(2)=="N" else -1)
-        lon = float(m2.group(1)) * (1 if m2.group(2)=="E" else -1)
+        lat = float(m1.group(1)) * (1 if m1.group(2) == "N" else -1)
+        lon = float(m2.group(1)) * (1 if m2.group(2) == "E" else -1)
     else:
         parts = re.split(r"[,\s]+", re.sub(r"[NSEW]", "", t).strip())
         if len(parts) >= 2:
             try:
                 lat, lon = float(parts[0]), float(parts[1])
-            except:
+            except ValueError:
                 return None
     if lat is None or lon is None:
         return None
     # swap if out of bounds
-    if not (LAT_MIN<=lat<=LAT_MAX) and (LAT_MIN<=lon<=LAT_MAX):
-        lat,lon = lon,lat
-    if not (LAT_MIN<=lat<=LAT_MAX and LON_MIN<=lon<=LON_MAX):
+    if not (LAT_MIN <= lat <= LAT_MAX) and (LON_MIN <= lon <= LON_MAX):
+        lat, lon = lon, lat
+    if not (LAT_MIN <= lat <= LAT_MAX and LON_MIN <= lon <= LON_MAX):
         return None
-    if _haversine(lat,lon,REF_LAT,REF_LON) > RADIUS_KM:
+    if _haversine(lat, lon, REF_LAT, REF_LON) > RADIUS_KM:
         print("⚠️  >500 km kaugusel kontrollpunktist.")
     return lat, lon
+
 
 # ───────── "TTS" as print ─────────
 def speak(text):
     print(f"[SPEAK] {text}")
+
 
 # ───────── Whisper STT (stdin) ─────────
 # Original audio recording disabled. Instead, prompt user for text.
 def record_and_transcribe(sec=5):
     return input("[STT] (type response) ")
 
+
 # ───────── MGRS helpers ─────────
-def to_mgrs(lat,lon): return MGRS().toMGRS(lat,lon)
+def to_mgrs(lat, lon):
+    return MGRS().toMGRS(lat, lon)
+
+
 def format_mgrs(m):
-    z = m[:5]; r = m[5:]; h = len(r)//2
+    z = m[:5]
+    r = m[5:]
+    h = len(r) // 2
     return f"{z} {r[:h]} {r[h:]}"
+
 
 # ───────── SALUTE (Estonian prompts) ─────────
 def salute_dialogue(loc_str):
     fields = [
-        ("size","Suurus"),
-        ("activity","Tegevus"),
-        ("location","Asukoht"),
-        ("unit","Üksus"),
-        ("time","Aeg"),
-        ("equipment","Varustus")
+        ("size", "Suurus"),
+        ("activity", "Tegevus"),
+        ("location", "Asukoht"),
+        ("unit", "Üksus"),
+        ("time", "Aeg"),
+        ("equipment", "Varustus"),
     ]
-    ans = {k:"" for k,_ in fields}
+    ans = {k: "" for k, _ in fields}
     ans["location"] = loc_str
     idx = 0
     while idx < len(fields):
@@ -183,27 +207,29 @@ def salute_dialogue(loc_str):
             parts = low.split()
             if len(parts) >= 2:
                 tgt = parts[1]
-                for j,(k,_) in enumerate(fields):
+                for j, (k, _) in enumerate(fields):
                     if tgt == k or tgt == _.lower():
                         idx = j
                         break
             continue
-        if low in ("vahele","skip","järgmine"):
+        if low in ("vahele", "skip", "järgmine"):
             ans[key] = ""
         else:
             ans[key] = txt
         idx += 1
 
     print("[SALUTE_REPORT]")
-    for k,et in fields:
+    for k, et in fields:
         print(f"{et}: {ans[k] or '–'}")
+
 
 # ───────── main ─────────
 def main():
     ap = argparse.ArgumentParser(description="Estonian multimodal CLI")
     ap.add_argument("--image", required=True, help="Pilt GPS-koordinaatidega")
-    ap.add_argument("--no-salute", action="store_true",
-                    help="Ära käivita SALUTE dialoogi")
+    ap.add_argument(
+        "--no-salute", action="store_true", help="Ära käivita SALUTE dialoogi"
+    )
     args = ap.parse_args()
 
     # 1) Tesseract OCR
@@ -239,6 +265,7 @@ def main():
 
     if not args.no_salute:
         salute_dialogue(mgrs)
+
 
 if __name__ == "__main__":
     main()

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -7,8 +7,20 @@ returned as Telegram text messages.
 """
 
 import os
+import random
+import re
 import tempfile
+import time
+import math
+import shutil
+import base64
+from mimetypes import guess_type
 from typing import Dict, List, Tuple
+
+from openai import OpenAI
+import pytesseract
+from PIL import Image, ImageEnhance
+from mgrs import MGRS
 
 from telegram import Update
 from telegram.ext import (
@@ -20,13 +32,6 @@ from telegram.ext import (
     ConversationHandler,
 )
 
-from multimodal_cli import (
-    tesseract_ocr,
-    gpt_vision_ocr,
-    parse_coords,
-    to_mgrs,
-    format_mgrs,
-)
 
 TELEGRAM_API_TOKEN = os.getenv("TELEGRAM_API_TOKEN")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
@@ -35,6 +40,16 @@ if not TELEGRAM_API_TOKEN:
     raise SystemExit("❌  Set TELEGRAM_API_TOKEN in your environment.")
 if not OPENAI_API_KEY:
     raise SystemExit("❌  Set OPENAI_API_KEY in your environment.")
+
+client = OpenAI(api_key=OPENAI_API_KEY)
+
+LAT_MIN, LAT_MAX = 55.0, 60.0
+LON_MIN, LON_MAX = 21.0, 28.0
+REF_LAT, REF_LON = 58.0, 25.0
+RADIUS_KM = 500.0
+
+if shutil.which("tesseract") is None:
+    print("⚠️  Tesseract not in PATH – OCR fallback will fail")
 
 FIELDS: List[Tuple[str, str]] = [
     ("size", "Suurus"),
@@ -45,6 +60,125 @@ FIELDS: List[Tuple[str, str]] = [
     ("equipment", "Varustus"),
 ]
 SALUTE = 1
+
+
+def retry(fn, *args, retries: int = 3, **kwargs):
+    for i in range(1, retries + 1):
+        try:
+            return fn(*args, **kwargs)
+        except Exception as e:
+            if i == retries:
+                raise
+            backoff = 2**i + random.random()
+            print(f"[Retry {i}/{retries}] {fn.__name__}: {e} → {backoff:.1f}s")
+            time.sleep(backoff)
+
+
+def to_data_url(path: str) -> str:
+    mime, _ = guess_type(path)
+    with open(path, "rb") as f:
+        b64 = base64.b64encode(f.read()).decode()
+    return f"data:{mime or 'application/octet-stream'};base64,{b64}"
+
+
+def _haversine(a1: float, a2: float, b1: float, b2: float) -> float:
+    R = 6371
+    dlat = math.radians(b1 - a1)
+    dlon = math.radians(b2 - a2)
+    h = (
+        math.sin(dlat / 2) ** 2
+        + math.cos(math.radians(a1))
+        * math.cos(math.radians(b1))
+        * math.sin(dlon / 2) ** 2
+    )
+    return R * 2 * math.asin(math.sqrt(h))
+
+
+def preprocess(img):
+    return ImageEnhance.Contrast(img.convert("L")).enhance(2.0)
+
+
+def tesseract_ocr(path: str) -> str:
+    try:
+        base = Image.open(path)
+    except Exception as e:
+        print(f"❌  Cannot open image: {e}")
+        return ""
+    out = ""
+    for angle in (0, 90, 180, 270):
+        txt = pytesseract.image_to_string(
+            preprocess(base.rotate(angle, expand=True)),
+            config="--psm 6 -c tessedit_char_whitelist=0123456789.,NSEW ",
+        ).strip()
+        print(f"[Tesseract {angle}°] {txt or '[no text]'}")
+        out = txt or out
+        if ("N" in txt or "S" in txt) and ("E" in txt or "W" in txt):
+            if parse_coords(txt):
+                break
+    return out
+
+
+def gpt_vision_ocr(path: str) -> str:
+    resp = retry(
+        client.chat.completions.create,
+        model="gpt-4o-mini",
+        input=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": (
+                            "Leia drooni ekraanil kuvatud GPS-koordinaadid ja vasta ainult "
+                            "kümnend-kraadides kujul, näiteks: 57.927336° N, 26.747699° E"
+                        ),
+                    },
+                    {"type": "input_image", "image_url": to_data_url(path)},
+                ],
+            }
+        ],
+        timeout=60,
+    )
+    return resp.output_text.strip()
+
+
+def parse_coords(txt: str):
+    if not txt:
+        return None
+    t = txt.upper().replace("°", "")
+    lat = lon = None
+    m1 = re.search(r"(-?\d+\.\d+)\s*([NS])", t)
+    m2 = re.search(r"(-?\d+\.\d+)\s*([EW])", t)
+    if m1 and m2:
+        lat = float(m1.group(1)) * (1 if m1.group(2) == "N" else -1)
+        lon = float(m2.group(1)) * (1 if m2.group(2) == "E" else -1)
+    else:
+        parts = re.split(r"[,\s]+", re.sub(r"[NSEW]", "", t).strip())
+        if len(parts) >= 2:
+            try:
+                lat, lon = float(parts[0]), float(parts[1])
+            except ValueError:
+                return None
+    if lat is None or lon is None:
+        return None
+    if not (LAT_MIN <= lat <= LAT_MAX) and (LON_MIN <= lon <= LON_MAX):
+        lat, lon = lon, lat
+    if not (LAT_MIN <= lat <= LAT_MAX and LON_MIN <= lon <= LON_MAX):
+        return None
+    if _haversine(lat, lon, REF_LAT, REF_LON) > RADIUS_KM:
+        print("⚠️  >500 km kaugusel kontrollpunktist.")
+    return lat, lon
+
+
+def to_mgrs(lat: float, lon: float) -> str:
+    return MGRS().toMGRS(lat, lon)
+
+
+def format_mgrs(m: str) -> str:
+    z = m[:5]
+    r = m[5:]
+    h = len(r) // 2
+    return f"{z} {r[:h]} {r[h:]}"
 
 
 def ocr_pipeline(path: str) -> Tuple[str, str] | Tuple[None, None]:


### PR DESCRIPTION
## Summary
- include all OCR and coordinate utilities directly in `telegram_bot.py`
- remove dependency on `multimodal_cli`

## Testing
- `black --line-length 88 telegram_bot.py multimodal_cli.py`
- `flake8 .` *(fails: command not found)*
- `pytest --maxfail=1 --disable-warnings -q`
