### PR TITLE
Centralize configuration and SALUTE conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,72 @@
-# MGRS
-OCR
+# MGRS OCR Toolkit
+
+Tools for extracting GPS coordinates from imagery, validating them against an
+Estonian reference window, converting to MGRS, and gathering structured SALUTE
+reports in Estonian.
+
+## Components
+
+### `multimodal_cli.py`
+Interactive command-line workflow that:
+
+1. Attempts OCR with Tesseract (rotating through four angles) and falls back to
+   the OpenAI GPT-4o-mini vision endpoint when needed.
+2. Validates coordinates within 500 km of the Estonia reference point before
+   converting them to MGRS.
+3. Prompts the user through a SALUTE report flow (stdin stub instead of audio).
+
+Usage:
+
+```bash
+export OPENAI_API_KEY=...  # required
+python multimodal_cli.py --image path/to/photo.jpg
+python multimodal_cli.py --image path/to/photo.jpg --no-salute  # skip dialogue
+python multimodal_cli.py --image path/to/photo.jpg --show-gmt    # print GMT clock
+```
+
+### `telegram_bot.py`
+A synchronous Telegram bot (python-telegram-bot v13) that listens for photos,
+extracts coordinates using the same OCR pipeline, replies with decimal + MGRS
+coordinates, and continues into the SALUTE questionnaire.
+
+Usage:
+
+```bash
+export OPENAI_API_KEY=...
+export TELEGRAM_API_TOKEN=...
+python telegram_bot.py
+```
+
+The bot stores no data server-side. Each chat session keeps the parsed MGRS in
+memory only for the SALUTE flow.
+
+### `ocr_shared.py`
+Shared OCR, coordinate parsing, and formatting helpers imported by both the CLI
+and Telegram entry points. The module owns the Estonia bounds, retry logic, and
+an :class:`OcrResult` data class that surfaces the decimal and MGRS strings so
+callers don’t have to duplicate parsing or formatting steps.
+
+### `config.py`
+Centralises environment-derived configuration (API tokens), Estonia geography
+bounds, and the ordered SALUTE fields so both front-ends share one source of
+truth.
+
+### `salute.py`
+Implements a reusable SALUTE conversation engine that handles prompts,
+skipping/backtracking, and report formatting. The CLI and Telegram bot both
+instantiate the same helper to keep behaviour aligned.
+
+### `logging_utils.py`
+Provides a consistent logging configuration and named loggers for the CLI and
+bot so diagnostics and retry messages use a single format.
+
+## Requirements
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+`pytesseract` expects the Tesseract binary to be installed and discoverable in
+`PATH`.

--- a/config.py
+++ b/config.py
@@ -1,0 +1,72 @@
+"""Application configuration helpers and shared constants."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+
+@dataclass(frozen=True)
+class GeoBounds:
+    """Geographic constraints for validating OCR results."""
+
+    lat_min: float = 55.0
+    lat_max: float = 60.0
+    lon_min: float = 21.0
+    lon_max: float = 28.0
+    ref_lat: float = 58.0
+    ref_lon: float = 25.0
+    radius_km: float = 500.0
+
+
+@dataclass(frozen=True)
+class SaluteField:
+    """Definition of a SALUTE field and its Estonian label."""
+
+    key: str
+    label: str
+
+
+DEFAULT_GEO_BOUNDS = GeoBounds()
+DEFAULT_SALUTE_FIELDS: Tuple[SaluteField, ...] = (
+    SaluteField("size", "Suurus"),
+    SaluteField("activity", "Tegevus"),
+    SaluteField("location", "Asukoht"),
+    SaluteField("unit", "Üksus"),
+    SaluteField("time", "Aeg"),
+    SaluteField("equipment", "Varustus"),
+)
+
+
+@dataclass(frozen=True)
+class AppConfig:
+    """Loaded application settings with optional tokens."""
+
+    openai_api_key: str
+    telegram_api_token: Optional[str]
+    geo: GeoBounds = DEFAULT_GEO_BOUNDS
+    salute_fields: Tuple[SaluteField, ...] = DEFAULT_SALUTE_FIELDS
+
+
+def load_config(*, require_openai: bool = False, require_telegram: bool = False) -> AppConfig:
+    """Load configuration from environment variables."""
+
+    openai_api_key = os.getenv("OPENAI_API_KEY", "")
+    telegram_api_token = os.getenv("TELEGRAM_API_TOKEN")
+
+    if require_openai and not openai_api_key:
+        raise RuntimeError("Set OPENAI_API_KEY in your environment.")
+    if require_telegram and not telegram_api_token:
+        raise RuntimeError("Set TELEGRAM_API_TOKEN in your environment.")
+
+    return AppConfig(openai_api_key=openai_api_key, telegram_api_token=telegram_api_token)
+
+
+__all__ = [
+    "AppConfig",
+    "GeoBounds",
+    "SaluteField",
+    "DEFAULT_GEO_BOUNDS",
+    "DEFAULT_SALUTE_FIELDS",
+    "load_config",
+]

--- a/logging_utils.py
+++ b/logging_utils.py
@@ -1,0 +1,22 @@
+"""Shared logging configuration helpers."""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+_DEFAULT_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+
+
+def configure_logging(*, level: int = logging.INFO, format: Optional[str] = None) -> None:
+    """Configure root logging with a consistent format."""
+
+    logging.basicConfig(level=level, format=format or _DEFAULT_FORMAT)
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a named logger using the shared configuration."""
+
+    return logging.getLogger(name)
+
+
+__all__ = ["configure_logging", "get_logger"]

--- a/multimodal_cli.py
+++ b/multimodal_cli.py
@@ -1,244 +1,131 @@
 #!/usr/bin/env python3
-"""
-multimodal_cli.py  –  May-2025 (Estonian voice edition)
+"""Estonian multimodal CLI with OCR→MGRS conversion and SALUTE dialogue."""
 
-1. Image → GPS (Tesseract first, GPT-4o-mini fallback)
-2. Estonia + 500 km sanity, MGRS conversion
-3. Mic → Whisper (language='et')   → SALUTE prompts
-4. Speech:
-      • printed messages only (no external TTS engines)
-
-Modified for testing without audio: user responds via stdin.
-"""
+from __future__ import annotations
 
 import argparse
-import base64
-import os
-import random
-import re
-import sys
-import tempfile
-import time
-import math
+import logging
 import shutil
-from mimetypes import guess_type
-from io import BytesIO
-# import wave
+import sys
+from datetime import datetime
 
-# ───────── third-party ─────────
-from openai import OpenAI
 import requests
-import pytesseract
-from PIL import Image, ImageEnhance
-# import sounddevice as sd
-# import numpy as np
-from mgrs import MGRS
+from openai import OpenAI
 
-# ─────────── constants ───────────
-LAT_MIN, LAT_MAX = 55.0, 60.0
-LON_MIN, LON_MAX = 21.0, 28.0
-REF_LAT, REF_LON = 58.0, 25.0
-RADIUS_KM = 500.0
+from config import AppConfig, load_config
+from logging_utils import configure_logging, get_logger
+from ocr_shared import run_ocr
+from salute import SaluteConversation
 
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-if not OPENAI_API_KEY:
-    sys.exit("❌  Set OPENAI_API_KEY in your environment.")
-client = OpenAI(api_key=OPENAI_API_KEY)
-
-if shutil.which("tesseract") is None:
-    print("⚠️  Tesseract not in PATH – OCR fallback will fail", file=sys.stderr)
-
-# ───────── retry utility ─────────
-def retry(fn, *args, retries=3, **kwargs):
-    for i in range(1, retries + 1):
-        try:
-            return fn(*args, **kwargs)
-        except Exception as e:
-            if i == retries:
-                raise
-            back = 2 ** i + random.random()
-            print(f"[Retry {i}/{retries}] {fn.__name__}: {e} → {back:.1f}s")
-            time.sleep(back)
-
-# ───────── helpers ─────────
-def to_data_url(path: str) -> str:
-    mime, _ = guess_type(path)
-    with open(path, "rb") as f:
-        b64 = base64.b64encode(f.read()).decode()
-    return f"data:{mime or 'application/octet-stream'};base64,{b64}"
-
-def _haversine(a1,a2,b1,b2):
-    R=6371
-    dlat=math.radians(b1-a1)
-    dlon=math.radians(b2-a2)
-    h=(math.sin(dlat/2)**2 +
-       math.cos(math.radians(a1))*
-       math.cos(math.radians(b1))*
-       math.sin(dlon/2)**2)
-    return R*2*math.asin(math.sqrt(h))
-
-# ───────── OCR pipeline ─────────
-def preprocess(img):
-    return ImageEnhance.Contrast(img.convert("L")).enhance(2.0)
-
-def tesseract_ocr(path):
-    try:
-        base = Image.open(path)
-    except Exception as e:
-        print("❌  Cannot open image:", e, file=sys.stderr)
-        return ""
-    out = ""
-    for angle in (0,90,180,270):
-        txt = pytesseract.image_to_string(
-            preprocess(base.rotate(angle, expand=True)),
-            config="--psm 6 -c tessedit_char_whitelist=0123456789.,NSEW "
-        ).strip()
-        print(f"\n[Tesseract {angle}°]\n{txt or '[no text]'}")
-        out = txt or out
-        if ("N" in txt or "S" in txt) and ("E" in txt or "W" in txt):
-            if parse_coords(txt):
-                return txt
-    return out
-
-def gpt_vision_ocr(path):
-    resp = retry(
-        client.responses.create,
-        model="gpt-4o-mini",
-        input=[{
-            "role": "user",
-            "content": [
-                {"type":"input_text", "text":
-                 "Leia drooni ekraanil kuvatud GPS-koordinaadid ja vasta ainult kümnend‑kraadides kujul, "
-                 "näiteks: 57.927336° N, 26.747699° E"},
-                {"type":"input_image","image_url":to_data_url(path)}
-            ]
-        }],
-        timeout=60
-    )
-    return resp.output_text.strip()
-
-# ───────── coordinate utils ─────────
-def parse_coords(txt):
-    if not txt:
-        return None
-    t = txt.upper().replace("°","")
-    lat = lon = None
-    m1 = re.search(r"(-?\d+\.\d+)\s*([NS])", t)
-    m2 = re.search(r"(-?\d+\.\d+)\s*([EW])", t)
-    if m1 and m2:
-        lat = float(m1.group(1)) * (1 if m1.group(2)=="N" else -1)
-        lon = float(m2.group(1)) * (1 if m2.group(2)=="E" else -1)
-    else:
-        parts = re.split(r"[,\s]+", re.sub(r"[NSEW]", "", t).strip())
-        if len(parts) >= 2:
-            try:
-                lat, lon = float(parts[0]), float(parts[1])
-            except:
-                return None
-    if lat is None or lon is None:
-        return None
-    # swap if out of bounds
-    if not (LAT_MIN<=lat<=LAT_MAX) and (LAT_MIN<=lon<=LAT_MAX):
-        lat,lon = lon,lat
-    if not (LAT_MIN<=lat<=LAT_MAX and LON_MIN<=lon<=LON_MAX):
-        return None
-    if _haversine(lat,lon,REF_LAT,REF_LON) > RADIUS_KM:
-        print("⚠️  >500 km kaugusel kontrollpunktist.")
-    return lat, lon
-
-# ───────── "TTS" as print ─────────
-def speak(text):
+def speak(text: str) -> None:
     print(f"[SPEAK] {text}")
 
-# ───────── Whisper STT (stdin) ─────────
-# Original audio recording disabled. Instead, prompt user for text.
-def record_and_transcribe(sec=5):
+
+def record_and_transcribe(sec: int = 5) -> str:  # noqa: ARG001 - placeholder shim
     return input("[STT] (type response) ")
 
-# ───────── MGRS helpers ─────────
-def to_mgrs(lat,lon): return MGRS().toMGRS(lat,lon)
-def format_mgrs(m):
-    z = m[:5]; r = m[5:]; h = len(r)//2
-    return f"{z} {r[:h]} {r[h:]}"
 
-# ───────── SALUTE (Estonian prompts) ─────────
-def salute_dialogue(loc_str):
-    fields = [
-        ("size","Suurus"),
-        ("activity","Tegevus"),
-        ("location","Asukoht"),
-        ("unit","Üksus"),
-        ("time","Aeg"),
-        ("equipment","Varustus")
-    ]
-    ans = {k:"" for k,_ in fields}
-    ans["location"] = loc_str
-    idx = 0
-    while idx < len(fields):
-        key, et = fields[idx]
-        print(f"[SALUTE_PROMPT] Palun ütle {et}. (või 'vahele'/'tagasi')")
-        txt = record_and_transcribe()
-        low = txt.lower()
-        if low.startswith("tagasi"):
-            parts = low.split()
-            if len(parts) >= 2:
-                tgt = parts[1]
-                for j,(k,_) in enumerate(fields):
-                    if tgt == k or tgt == _.lower():
-                        idx = j
-                        break
-            continue
-        if low in ("vahele","skip","järgmine"):
-            ans[key] = ""
-        else:
-            ans[key] = txt
-        idx += 1
+def fetch_gmt_time() -> str:
+    """Return the current GMT timestamp using worldtimeapi.org."""
 
-    print("[SALUTE_REPORT]")
-    for k,et in fields:
-        print(f"{et}: {ans[k] or '–'}")
+    resp = requests.get("https://worldtimeapi.org/api/timezone/Etc/GMT", timeout=10)
+    resp.raise_for_status()
+    payload = resp.json()
+    dt = datetime.fromisoformat(payload["datetime"])
+    return dt.strftime("%Y-%m-%d %H:%M:%S %Z%z")
 
-# ───────── main ─────────
-def main():
-    ap = argparse.ArgumentParser(description="Estonian multimodal CLI")
-    ap.add_argument("--image", required=True, help="Pilt GPS-koordinaatidega")
-    ap.add_argument("--no-salute", action="store_true",
-                    help="Ära käivita SALUTE dialoogi")
-    args = ap.parse_args()
 
-    # 1) Tesseract OCR
-    raw_ocr = tesseract_ocr(args.image)
-    print("\n=== Tesseract OCR ===\n", raw_ocr or "[tühi]")
+def salute_dialogue(conversation: SaluteConversation) -> None:
+    """Drive the SALUTE prompts using stdin-backed responses."""
 
-    # 2) parse
-    coords = parse_coords(raw_ocr)
+    while True:
+        print(f"[SALUTE_PROMPT] {conversation.prompt()}")
+        response = record_and_transcribe()
+        result = conversation.handle(response)
+        if result.completed:
+            print("[SALUTE_REPORT]")
+            for line in result.report_lines or ():
+                print(line)
+            break
 
-    if coords:
-        print("[Info] OCR found valid coordinates; skipping LLM OCR.")
-    else:
-        # 3) fallback to GPT vision OCR
-        try:
-            raw_llm = gpt_vision_ocr(args.image)
-            print("\n=== GPT-4o-mini ===\n", raw_llm or "[tühi]")
-            coords = parse_coords(raw_llm)
-        except Exception as e:
-            print(f"[LLM error] {e}", file=sys.stderr)
 
-    # 4) bail if still none
-    if not coords:
+def warn_if_missing_tesseract(logger: logging.Logger) -> None:
+    if shutil.which("tesseract") is None:
+        logger.warning("Tesseract not in PATH – OCR fallback will fail")
+
+
+def build_client(config: AppConfig) -> OpenAI:
+    return OpenAI(api_key=config.openai_api_key)
+
+
+def run_cli(args, config: AppConfig) -> None:
+    logger = get_logger("multimodal_cli")
+    warn_if_missing_tesseract(logger)
+
+    client = build_client(config)
+
+    def report_raw(engine: str, text: str) -> None:
+        print(f"\n=== {engine} ===\n", text or "[tühi]")
+
+    try:
+        ocr_result = run_ocr(
+            args.image,
+            client,
+            logger=logger,
+            on_raw=report_raw,
+            geo=config.geo,
+        )
+    except Exception as exc:  # pragma: no cover - network failure path
+        logger.error("OCR pipeline failed: %s", exc)
+        ocr_result = None
+
+    if not ocr_result:
         sys.exit("❌  Koordinaate ei saanud kätte.")
 
-    # 5) output
-    lat, lon = coords
-    dec = f"{abs(lat):.6f}° {'N' if lat>=0 else 'S'}, {abs(lon):.6f}° {'E' if lon>=0 else 'W'}"
-    mgrs = format_mgrs(to_mgrs(lat, lon))
-    print(f"\n[RESULT] Koordinaadid leitud. {dec}")
-    print(f"[MGRS] {mgrs}")
+    print(f"[INFO] Kasutasin {ocr_result.engine} OCR-i (✔︎)")
+    print(f"\n[RESULT] ({ocr_result.engine}) Koordinaadid leitud. {ocr_result.decimal}")
+    print(f"[MGRS] {ocr_result.mgrs}")
 
-    speak(f"Koordinaadid leitud. {dec}")
+    speak(f"Koordinaadid leitud. {ocr_result.decimal}")
+
+    if args.show_gmt:
+        try:
+            print(f"[GMT] {fetch_gmt_time()}")
+        except requests.RequestException as exc:
+            logger.warning("GMT fetch failed: %s", exc)
 
     if not args.no_salute:
-        salute_dialogue(mgrs)
+        conversation = SaluteConversation(
+            fields=config.salute_fields,
+            location=ocr_result.mgrs,
+        )
+        salute_dialogue(conversation)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Estonian multimodal CLI")
+    parser.add_argument("--image", required=True, help="Pilt GPS-koordinaatidega")
+    parser.add_argument(
+        "--no-salute",
+        action="store_true",
+        help="Ära käivita SALUTE dialoogi",
+    )
+    parser.add_argument(
+        "--show-gmt",
+        action="store_true",
+        help="Kuva praegune GMT kellaaeg worldtimeapi.org teenusest",
+    )
+    args = parser.parse_args()
+
+    configure_logging()
+
+    try:
+        config = load_config(require_openai=True)
+    except RuntimeError as exc:
+        sys.exit(f"❌  {exc}")
+
+    run_cli(args, config)
+
 
 if __name__ == "__main__":
     main()

--- a/ocr_shared.py
+++ b/ocr_shared.py
@@ -1,0 +1,286 @@
+"""Shared OCR and coordinate utilities for the CLI and Telegram workflows."""
+from __future__ import annotations
+
+import base64
+import logging
+import math
+import random
+import re
+import sys
+import time
+from dataclasses import dataclass
+from mimetypes import guess_type
+from typing import Callable, Iterable, Optional, Tuple
+
+import pytesseract
+from PIL import Image, ImageEnhance
+from mgrs import MGRS
+
+from config import DEFAULT_GEO_BOUNDS, GeoBounds
+
+LAT_MIN = DEFAULT_GEO_BOUNDS.lat_min
+LAT_MAX = DEFAULT_GEO_BOUNDS.lat_max
+LON_MIN = DEFAULT_GEO_BOUNDS.lon_min
+LON_MAX = DEFAULT_GEO_BOUNDS.lon_max
+REF_LAT = DEFAULT_GEO_BOUNDS.ref_lat
+REF_LON = DEFAULT_GEO_BOUNDS.ref_lon
+RADIUS_KM = DEFAULT_GEO_BOUNDS.radius_km
+
+_DEFAULT_PROMPT = (
+    "Leia drooni ekraanil kuvatud GPS-koordinaadid ja vasta ainult kümnendkraadides, "
+    "nt: 57.927336° N, 26.747699° E"
+)
+_DEFAULT_ANGLES: Tuple[int, ...] = (0, 90, 180, 270)
+
+
+@dataclass
+class OcrResult:
+    """Normalized OCR output containing both coordinate formats."""
+
+    lat: float
+    lon: float
+    engine: str
+    raw_text: str
+
+    @property
+    def decimal(self) -> str:
+        return format_decimal(self.lat, self.lon)
+
+    @property
+    def mgrs(self) -> str:
+        return format_mgrs(to_mgrs(self.lat, self.lon))
+
+
+def retry(
+    fn: Callable,
+    *args,
+    retries: int = 3,
+    logger: Optional[logging.Logger] = None,
+    **kwargs,
+):
+    """Retry helper with exponential backoff and jitter."""
+
+    for attempt in range(1, retries + 1):
+        try:
+            return fn(*args, **kwargs)
+        except Exception as exc:  # pragma: no cover - network failure path
+            if attempt == retries:
+                raise
+            backoff = 2 ** attempt + random.random()
+            if logger:
+                logger.debug("[retry %d/%d] %s → %.1fs", attempt, retries, exc, backoff)
+            else:
+                print(
+                    f"[Retry {attempt}/{retries}] {fn.__name__}: {exc} → {backoff:.1f}s",
+                    file=sys.stderr,
+                )
+            time.sleep(backoff)
+
+
+def to_data_url(path: str) -> str:
+    """Return the file contents encoded as a data URL."""
+
+    mime, _ = guess_type(path)
+    with open(path, "rb") as handle:
+        b64 = base64.b64encode(handle.read()).decode()
+    return f"data:{mime or 'image/jpeg'};base64,{b64}"
+
+
+def _haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    radius = 6371.0
+    dlat = math.radians(lat2 - lat1)
+    dlon = math.radians(lon2 - lon1)
+    a = (
+        math.sin(dlat / 2) ** 2
+        + math.cos(math.radians(lat1))
+        * math.cos(math.radians(lat2))
+        * math.sin(dlon / 2) ** 2
+    )
+    return radius * 2 * math.asin(math.sqrt(a))
+
+
+def preprocess(img: Image.Image) -> Image.Image:
+    """Greyscale and boost contrast to aid OCR accuracy."""
+
+    return ImageEnhance.Contrast(img.convert("L")).enhance(2.0)
+
+
+def tesseract_ocr(
+    path: str,
+    *,
+    angles: Iterable[int] = _DEFAULT_ANGLES,
+    psm: int = 7,
+    whitelist: str = "0123456789.,NSEW° ",
+    logger: Optional[logging.Logger] = None,
+    geo: GeoBounds = DEFAULT_GEO_BOUNDS,
+) -> str:
+    """Run Tesseract OCR against the provided image path."""
+
+    try:
+        base = Image.open(path)
+    except Exception as exc:  # pragma: no cover - file failure path
+        if logger:
+            logger.error("Cannot open %s: %s", path, exc)
+        else:
+            print("❌  Cannot open image:", exc, file=sys.stderr)
+        return ""
+
+    best_txt = ""
+    for angle in angles:
+        txt = pytesseract.image_to_string(
+            preprocess(base.rotate(angle, expand=True)),
+            config=f"--psm {psm} -c tessedit_char_whitelist={whitelist}",
+        ).strip()
+        if logger:
+            logger.debug("[Tesseract %d°] %s", angle, txt or "[no text]")
+        else:
+            print(f"\n[Tesseract {angle}°]\n{txt or '[no text]'}")
+        if txt:
+            best_txt = txt
+        if parse_coords(txt, logger=logger, geo=geo):
+            return txt
+    return best_txt
+
+
+def gpt_vision_ocr(
+    path: str,
+    client,
+    *,
+    prompt: str = _DEFAULT_PROMPT,
+    logger: Optional[logging.Logger] = None,
+) -> str:
+    """Query the GPT-4o-mini vision endpoint for coordinates."""
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": prompt},
+                {"type": "image_url", "image_url": {"url": to_data_url(path)}},
+            ],
+        }
+    ]
+    resp = retry(
+        client.chat.completions.create,
+        model="gpt-4o-mini",
+        messages=messages,
+        timeout=60,
+        logger=logger,
+    )
+    return resp.choices[0].message.content.strip()
+
+
+def _strip_dir_suffix(value: str) -> str:
+    return re.sub(r"[NSEW]$", "", value, flags=re.IGNORECASE)
+
+
+def parse_coords(
+    txt: Optional[str],
+    *,
+    logger: Optional[logging.Logger] = None,
+    geo: GeoBounds = DEFAULT_GEO_BOUNDS,
+) -> Optional[Tuple[float, float]]:
+    """Normalize decimal-degree coordinates from OCR text."""
+
+    if not txt:
+        return None
+    t = txt.upper().replace("°", " ")
+
+    match_lat = re.search(r"(-?\d+\.\d+)\s*([NS])", t)
+    match_lon = re.search(r"(-?\d+\.\d+)\s*([EW])", t)
+    if match_lat and match_lon:
+        lat = float(match_lat.group(1)) * (1 if match_lat.group(2) == "N" else -1)
+        lon = float(match_lon.group(1)) * (1 if match_lon.group(2) == "E" else -1)
+    else:
+        parts = [_strip_dir_suffix(p) for p in re.split(r"[,\s]+", t) if p]
+        if len(parts) < 2:
+            return None
+        try:
+            lat, lon = float(parts[0]), float(parts[1])
+        except ValueError:
+            return None
+
+    if not (geo.lat_min <= lat <= geo.lat_max):
+        if (geo.lon_min <= lat <= geo.lon_max) and (
+            geo.lat_min <= lon <= geo.lat_max
+        ):
+            lat, lon = lon, lat
+
+    if not (geo.lat_min <= lat <= geo.lat_max and geo.lon_min <= lon <= geo.lon_max):
+        return None
+
+    if _haversine(lat, lon, geo.ref_lat, geo.ref_lon) > geo.radius_km:
+        if logger:
+            logger.warning(">500km from ref: %.6f, %.6f", lat, lon)
+        else:
+            print("⚠️  >500 km kaugusel kontrollpunktist.")
+    return lat, lon
+
+
+def to_mgrs(lat: float, lon: float) -> str:
+    return MGRS().toMGRS(lat, lon)
+
+
+def format_mgrs(mgrs: str) -> str:
+    zone = mgrs[:5]
+    remainder = mgrs[5:]
+    half = len(remainder) // 2
+    return f"{zone} {remainder[:half]} {remainder[half:]}"
+
+
+def format_decimal(lat: float, lon: float) -> str:
+    return (
+        f"{abs(lat):.6f}° {'N' if lat >= 0 else 'S'}, "
+        f"{abs(lon):.6f}° {'E' if lon >= 0 else 'W'}"
+    )
+
+
+def run_ocr(
+    path: str,
+    client,
+    *,
+    logger: Optional[logging.Logger] = None,
+    on_raw: Optional[Callable[[str, str], None]] = None,
+    geo: GeoBounds = DEFAULT_GEO_BOUNDS,
+) -> Optional[OcrResult]:
+    """Execute the OCR pipeline and return structured coordinates if found."""
+
+    raw = tesseract_ocr(path, logger=logger, geo=geo)
+    if on_raw:
+        on_raw("Tesseract OCR", raw)
+    coords = parse_coords(raw, logger=logger, geo=geo)
+    if coords:
+        lat, lon = coords
+        return OcrResult(lat=lat, lon=lon, engine="Tesseract", raw_text=raw)
+
+    raw = gpt_vision_ocr(path, client, logger=logger)
+    if on_raw:
+        on_raw("GPT-4o-mini Vision", raw)
+    coords = parse_coords(raw, logger=logger, geo=geo)
+    if not coords:
+        return None
+
+    lat, lon = coords
+    return OcrResult(lat=lat, lon=lon, engine="GPT-4o-mini Vision", raw_text=raw)
+
+
+__all__ = [
+    "LAT_MIN",
+    "LAT_MAX",
+    "LON_MIN",
+    "LON_MAX",
+    "REF_LAT",
+    "REF_LON",
+    "RADIUS_KM",
+    "OcrResult",
+    "retry",
+    "to_data_url",
+    "preprocess",
+    "tesseract_ocr",
+    "gpt_vision_ocr",
+    "parse_coords",
+    "to_mgrs",
+    "format_mgrs",
+    "format_decimal",
+    "run_ocr",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 pytesseract
 Pillow
 mgrs
+python-telegram-bot>=13,<14

--- a/salute.py
+++ b/salute.py
@@ -1,0 +1,92 @@
+"""Reusable SALUTE conversation engine."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Sequence, Tuple
+
+from config import DEFAULT_SALUTE_FIELDS, SaluteField
+
+
+@dataclass
+class SaluteStepResult:
+    """Outcome of handling a single SALUTE response."""
+
+    completed: bool
+    prompt: Optional[str] = None
+    report_lines: Optional[Tuple[str, ...]] = None
+
+
+@dataclass
+class SaluteConversation:
+    """Stateful helper that tracks SALUTE answers and progression."""
+
+    fields: Sequence[SaluteField] = DEFAULT_SALUTE_FIELDS
+    location: str = ""
+    answers: Dict[str, str] = field(default_factory=dict)
+    index: int = 0
+
+    def __post_init__(self) -> None:
+        for field in self.fields:
+            self.answers.setdefault(field.key, "")
+        if self.location:
+            self.answers["location"] = self.location
+
+    def set_location(self, location: str) -> None:
+        """Update the location field with the current MGRS string."""
+
+        self.answers["location"] = location
+
+    def prompt(self) -> str:
+        """Return the prompt for the current SALUTE field."""
+
+        field = self.fields[self.index]
+        return f"Palun ütle {field.label}. (või 'vahele'/'tagasi')"
+
+    def handle(self, text: str) -> SaluteStepResult:
+        """Process the user's response and advance or rewind as needed."""
+
+        normalized = (text or "").strip()
+        lowered = normalized.lower()
+
+        if lowered.startswith("tagasi"):
+            self._rewind(lowered)
+            return SaluteStepResult(completed=False, prompt=self.prompt())
+
+        field = self.fields[self.index]
+        if lowered in {"vahele", "skip", "järgmine"}:
+            self.answers[field.key] = ""
+        else:
+            self.answers[field.key] = normalized
+
+        self.index += 1
+        if self.index >= len(self.fields):
+            return SaluteStepResult(completed=True, report_lines=self.render_report_lines())
+
+        return SaluteStepResult(completed=False, prompt=self.prompt())
+
+    def render_report_lines(self) -> Tuple[str, ...]:
+        """Produce formatted SALUTE report lines."""
+
+        return tuple(
+            f"{field.label}: {self.answers.get(field.key) or '–'}" for field in self.fields
+        )
+
+    def _rewind(self, lowered: str) -> None:
+        parts = lowered.split(maxsplit=1)
+        if len(parts) == 2:
+            target = parts[1]
+            target_idx = self._find_field_index(target)
+            if target_idx is not None:
+                self.index = target_idx
+                return
+        self.index = max(self.index - 1, 0)
+
+    def _find_field_index(self, token: str) -> Optional[int]:
+        token = token.strip().lower()
+        for idx, field in enumerate(self.fields):
+            if token == field.key or token == field.label.lower():
+                return idx
+        return None
+
+
+__all__ = ["SaluteConversation", "SaluteStepResult"]

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Telegram bot that performs OCR→MGRS conversion and SALUTE collection."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from typing import Optional
+
+from openai import OpenAI
+from telegram import Update
+from telegram.ext import (
+    CallbackContext,
+    CommandHandler,
+    ConversationHandler,
+    Filters,
+    MessageHandler,
+    Updater,
+)
+
+from config import AppConfig, load_config
+from logging_utils import configure_logging, get_logger
+from ocr_shared import run_ocr
+from salute import SaluteConversation
+
+SALUTE = 1
+
+LOGGER = get_logger("telegram_bot")
+CONFIG: Optional[AppConfig] = None
+CLIENT: Optional[OpenAI] = None
+
+
+def start(update: Update, context: CallbackContext) -> None:
+    update.message.reply_text(
+        "Tere! Saada mulle pilt GPS-koordinaatidega, et ma saaks need välja lugeda."
+    )
+
+
+def get_conversation(context: CallbackContext) -> SaluteConversation:
+    config = CONFIG
+    if config is None:
+        raise RuntimeError("Configuration not initialised")
+    conversation = context.user_data.get("salute_conv")
+    if isinstance(conversation, SaluteConversation):
+        return conversation
+    conversation = SaluteConversation(fields=config.salute_fields)
+    context.user_data["salute_conv"] = conversation
+    return conversation
+
+
+def ask_salute(update: Update, context: CallbackContext) -> int:
+    conversation = get_conversation(context)
+    update.message.reply_text(conversation.prompt())
+    return SALUTE
+
+
+def salute_handler(update: Update, context: CallbackContext) -> int:
+    conversation = get_conversation(context)
+    result = conversation.handle(update.message.text or "")
+
+    if result.completed:
+        report = "\n".join(result.report_lines or ())
+        update.message.reply_text("SALUTE raport:\n" + report)
+        return ConversationHandler.END
+
+    update.message.reply_text(result.prompt or conversation.prompt())
+    return SALUTE
+
+
+def handle_photo(update: Update, context: CallbackContext) -> int:
+    assert CLIENT is not None
+    assert CONFIG is not None
+
+    photo = update.message.photo[-1]
+    tg_file = context.bot.get_file(photo.file_id)
+
+    tmp = tempfile.NamedTemporaryFile(suffix=".jpg", delete=False)
+    tmp.close()
+    path = tmp.name
+
+    try:
+        tg_file.download(path)
+        try:
+            result = run_ocr(path, CLIENT, logger=LOGGER, geo=CONFIG.geo)
+        except Exception as exc:  # pragma: no cover - network failure path
+            LOGGER.error("OCR pipeline failed: %s", exc)
+            result = None
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            LOGGER.debug("Failed to delete temporary file: %s", path)
+
+    if not result:
+        update.message.reply_text("Koordinaate ei saanud kätte.")
+        return ConversationHandler.END
+
+    update.message.reply_text(f"📍 Koordinaadid: {result.decimal}\n🗺 MGRS: {result.mgrs}")
+    context.user_data["salute_conv"] = SaluteConversation(
+        fields=CONFIG.salute_fields,
+        location=result.mgrs,
+    )
+    return ask_salute(update, context)
+
+
+def cancel(update: Update, context: CallbackContext) -> int:
+    update.message.reply_text("Vestlus katkestatud.")
+    return ConversationHandler.END
+
+
+def main() -> None:
+    configure_logging()
+
+    try:
+        config = load_config(require_openai=True, require_telegram=True)
+    except RuntimeError as exc:
+        raise SystemExit(f"❌  {exc}") from exc
+
+    global CONFIG, CLIENT
+    CONFIG = config
+    CLIENT = OpenAI(api_key=config.openai_api_key)
+
+    if shutil.which("tesseract") is None:
+        LOGGER.warning("Tesseract not in PATH – OCR fallback will fail")
+
+    updater = Updater(token=config.telegram_api_token, use_context=True)
+    dispatcher = updater.dispatcher
+
+    conv = ConversationHandler(
+        entry_points=[MessageHandler(Filters.photo, handle_photo)],
+        states={SALUTE: [MessageHandler(Filters.text & ~Filters.command, salute_handler)]},
+        fallbacks=[CommandHandler("cancel", cancel)],
+    )
+
+    dispatcher.add_handler(CommandHandler("start", start))
+    dispatcher.add_handler(conv)
+
+    LOGGER.info("Bot starting…")
+    updater.start_polling()
+    updater.idle()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add shared configuration, logging, and SALUTE conversation modules so both entry points reuse the same helpers
- update the CLI to depend on the new configuration loader, shared SALUTE engine, and unified logging setup
- refactor the Telegram bot to initialise configuration once, reuse the conversation helper, and feed geo bounds into the OCR pipeline

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d9aadf9ed8832d8538225da2f39824