### PR TITLE
Add SALUTE conversation helper and OCR parsing tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,10 +32,11 @@ This agent assists with:
 - **STT**: simulated via `input()` (replace with Whisper and sounddevice if needed)
 
 ## 4. Testing & Quality
-- **Unit tests**: use `pytest` (place tests under `tests/`)  
+- **Unit tests**: use `pytest` (place tests under `tests/`)
   ```bash
   pytest --maxfail=1 --disable-warnings -q
   ```
+  The suite includes OCR parsing edge cases and SALUTE conversation flows.
 - **Linters/Formatters**:  
   ```bash
   flake8 .

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # MGRS
-OCR
+
+Utility scripts for reading drone imagery, parsing coordinates, and guiding an
+operator through a SALUTE report.
+
+## Development
+
+Create a virtual environment and install dependencies from `requirements.txt`.
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Tests
+
+Unit tests live under `tests/` and are executed with `pytest`.
+
+```bash
+pytest --maxfail=1 --disable-warnings -q
+```

--- a/multimodal_cli.py
+++ b/multimodal_cli.py
@@ -15,11 +15,9 @@ import argparse
 import base64
 import os
 import random
-import re
 import sys
 import tempfile
 import time
-import math
 import shutil
 from mimetypes import guess_type
 from io import BytesIO
@@ -34,11 +32,8 @@ from PIL import Image, ImageEnhance
 # import numpy as np
 from mgrs import MGRS
 
-# ─────────── constants ───────────
-LAT_MIN, LAT_MAX = 55.0, 60.0
-LON_MIN, LON_MAX = 21.0, 28.0
-REF_LAT, REF_LON = 58.0, 25.0
-RADIUS_KM = 500.0
+from ocr_shared import parse_coords
+from salute_conversation import SaluteConversation
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 if not OPENAI_API_KEY:
@@ -66,16 +61,6 @@ def to_data_url(path: str) -> str:
     with open(path, "rb") as f:
         b64 = base64.b64encode(f.read()).decode()
     return f"data:{mime or 'application/octet-stream'};base64,{b64}"
-
-def _haversine(a1,a2,b1,b2):
-    R=6371
-    dlat=math.radians(b1-a1)
-    dlon=math.radians(b2-a2)
-    h=(math.sin(dlat/2)**2 +
-       math.cos(math.radians(a1))*
-       math.cos(math.radians(b1))*
-       math.sin(dlon/2)**2)
-    return R*2*math.asin(math.sqrt(h))
 
 # ───────── OCR pipeline ─────────
 def preprocess(img):
@@ -118,34 +103,6 @@ def gpt_vision_ocr(path):
     return resp.output_text.strip()
 
 # ───────── coordinate utils ─────────
-def parse_coords(txt):
-    if not txt:
-        return None
-    t = txt.upper().replace("°","")
-    lat = lon = None
-    m1 = re.search(r"(-?\d+\.\d+)\s*([NS])", t)
-    m2 = re.search(r"(-?\d+\.\d+)\s*([EW])", t)
-    if m1 and m2:
-        lat = float(m1.group(1)) * (1 if m1.group(2)=="N" else -1)
-        lon = float(m2.group(1)) * (1 if m2.group(2)=="E" else -1)
-    else:
-        parts = re.split(r"[,\s]+", re.sub(r"[NSEW]", "", t).strip())
-        if len(parts) >= 2:
-            try:
-                lat, lon = float(parts[0]), float(parts[1])
-            except:
-                return None
-    if lat is None or lon is None:
-        return None
-    # swap if out of bounds
-    if not (LAT_MIN<=lat<=LAT_MAX) and (LAT_MIN<=lon<=LAT_MAX):
-        lat,lon = lon,lat
-    if not (LAT_MIN<=lat<=LAT_MAX and LON_MIN<=lon<=LON_MAX):
-        return None
-    if _haversine(lat,lon,REF_LAT,REF_LON) > RADIUS_KM:
-        print("⚠️  >500 km kaugusel kontrollpunktist.")
-    return lat, lon
-
 # ───────── "TTS" as print ─────────
 def speak(text):
     print(f"[SPEAK] {text}")
@@ -163,40 +120,16 @@ def format_mgrs(m):
 
 # ───────── SALUTE (Estonian prompts) ─────────
 def salute_dialogue(loc_str):
-    fields = [
-        ("size","Suurus"),
-        ("activity","Tegevus"),
-        ("location","Asukoht"),
-        ("unit","Üksus"),
-        ("time","Aeg"),
-        ("equipment","Varustus")
-    ]
-    ans = {k:"" for k,_ in fields}
-    ans["location"] = loc_str
-    idx = 0
-    while idx < len(fields):
-        key, et = fields[idx]
+    convo = SaluteConversation(location_prefill=loc_str)
+    while not convo.is_complete:
+        key, et = convo.current_field
         print(f"[SALUTE_PROMPT] Palun ütle {et}. (või 'vahele'/'tagasi')")
         txt = record_and_transcribe()
-        low = txt.lower()
-        if low.startswith("tagasi"):
-            parts = low.split()
-            if len(parts) >= 2:
-                tgt = parts[1]
-                for j,(k,_) in enumerate(fields):
-                    if tgt == k or tgt == _.lower():
-                        idx = j
-                        break
-            continue
-        if low in ("vahele","skip","järgmine"):
-            ans[key] = ""
-        else:
-            ans[key] = txt
-        idx += 1
+        convo.handle_response(txt)
 
     print("[SALUTE_REPORT]")
-    for k,et in fields:
-        print(f"{et}: {ans[k] or '–'}")
+    for line in convo.report_lines():
+        print(line)
 
 # ───────── main ─────────
 def main():

--- a/ocr_shared.py
+++ b/ocr_shared.py
@@ -1,0 +1,78 @@
+"""Shared OCR and coordinate utilities for the multimodal CLI."""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import Optional, Tuple
+
+LAT_MIN, LAT_MAX = 55.0, 60.0
+LON_MIN, LON_MAX = 21.0, 28.0
+REF_LAT, REF_LON = 58.0, 25.0
+RADIUS_KM = 500.0
+
+
+def _haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Return the distance in kilometres between two decimal degree pairs."""
+
+    radius = 6371.0
+    dlat = math.radians(lat2 - lat1)
+    dlon = math.radians(lon2 - lon1)
+    a = (
+        math.sin(dlat / 2) ** 2
+        + math.cos(math.radians(lat1))
+        * math.cos(math.radians(lat2))
+        * math.sin(dlon / 2) ** 2
+    )
+    return radius * 2 * math.asin(math.sqrt(a))
+
+
+def parse_coords(txt: str) -> Optional[Tuple[float, float]]:
+    """Parse decimal latitude/longitude text and validate the result."""
+
+    if not txt:
+        return None
+
+    cleaned = txt.upper().replace("°", "")
+    lat = lon = None
+
+    match_lat = re.search(r"(-?\d+\.\d+)\s*([NS])", cleaned)
+    match_lon = re.search(r"(-?\d+\.\d+)\s*([EW])", cleaned)
+
+    if match_lat and match_lon:
+        lat = float(match_lat.group(1)) * (1 if match_lat.group(2) == "N" else -1)
+        lon = float(match_lon.group(1)) * (1 if match_lon.group(2) == "E" else -1)
+    else:
+        parts = re.split(r"[,\s]+", re.sub(r"[NSEW]", "", cleaned).strip())
+        if len(parts) >= 2:
+            try:
+                lat, lon = float(parts[0]), float(parts[1])
+            except ValueError:
+                return None
+
+    if lat is None or lon is None:
+        return None
+
+    if not (LAT_MIN <= lat <= LAT_MAX) and (LAT_MIN <= lon <= LAT_MAX):
+        lat, lon = lon, lat
+
+    if not (LAT_MIN <= lat <= LAT_MAX and LON_MIN <= lon <= LON_MAX):
+        return None
+
+    if _haversine(lat, lon, REF_LAT, REF_LON) > RADIUS_KM:
+        print("⚠️  >500 km kaugusel kontrollpunktist.")
+
+    return lat, lon
+
+
+__all__ = [
+    "LAT_MIN",
+    "LAT_MAX",
+    "LON_MIN",
+    "LON_MAX",
+    "REF_LAT",
+    "REF_LON",
+    "RADIUS_KM",
+    "_haversine",
+    "parse_coords",
+]

--- a/salute_conversation.py
+++ b/salute_conversation.py
@@ -1,0 +1,97 @@
+"""Stateful SALUTE conversation helper for CLI and tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Sequence, Tuple
+
+
+@dataclass
+class SaluteConversation:
+    """Maintain SALUTE prompt state and handle control commands."""
+
+    location_prefill: str = ""
+    fields: Sequence[Tuple[str, str]] = (
+        ("size", "Suurus"),
+        ("activity", "Tegevus"),
+        ("location", "Asukoht"),
+        ("unit", "Üksus"),
+        ("time", "Aeg"),
+        ("equipment", "Varustus"),
+    )
+    skip_words: Sequence[str] = ("vahele", "skip", "järgmine")
+    rewind_word: str = "tagasi"
+    answers: dict = field(init=False)
+    index: int = field(default=0, init=False)
+
+    def __post_init__(self) -> None:
+        self.answers = {key: "" for key, _ in self.fields}
+        if "location" in self.answers and self.location_prefill:
+            self.answers["location"] = self.location_prefill
+
+    @property
+    def is_complete(self) -> bool:
+        """Return whether every SALUTE field has been filled or skipped."""
+
+        return self.index >= len(self.fields)
+
+    @property
+    def current_field(self) -> Tuple[str, str]:
+        """Return the active field key/label pair."""
+
+        if self.is_complete:
+            raise IndexError("Conversation already complete.")
+        return self.fields[self.index]
+
+    def prompt_text(self) -> str:
+        """Return the CLI prompt for the current field."""
+
+        _, label = self.current_field
+        return f"[SALUTE_PROMPT] Palun ütle {label}. (või 'vahele'/'tagasi')"
+
+    def handle_response(self, response: str) -> None:
+        """Process a user response and update the conversation state."""
+
+        response = response or ""
+        lowered = response.strip().lower()
+
+        if lowered.startswith(self.rewind_word):
+            self._rewind(lowered)
+            return
+
+        key, _ = self.current_field
+
+        if lowered in self.skip_words:
+            if key == "location" and self.answers.get(key):
+                pass
+            else:
+                self.answers[key] = ""
+            self.index += 1
+            return
+
+        self.answers[key] = response
+        self.index += 1
+
+    def _rewind(self, lowered_response: str) -> None:
+        """Move the pointer to a previous field based on the response."""
+
+        parts = lowered_response.split(maxsplit=1)
+        if len(parts) == 1:
+            self.index = max(0, self.index - 1)
+            return
+
+        target = parts[1]
+        for pos, (key, label) in enumerate(self.fields):
+            if target == key.lower() or target == label.lower():
+                self.index = pos
+                return
+
+        self.index = max(0, self.index - 1)
+
+    def report_lines(self) -> List[str]:
+        """Return formatted SALUTE report lines in Estonian order."""
+
+        return [f"{label}: {self.answers[key] or '–'}" for key, label in self.fields]
+
+
+__all__ = ["SaluteConversation"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Test configuration and shared fixtures."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_ocr_shared.py
+++ b/tests/test_ocr_shared.py
@@ -1,0 +1,28 @@
+"""Tests for OCR coordinate parsing helpers."""
+
+import pytest
+
+import ocr_shared
+
+
+def test_parse_coords_swaps_lat_lon_when_needed():
+    lat, lon = ocr_shared.parse_coords("26.123 58.456")
+
+    assert lat == pytest.approx(58.456)
+    assert lon == pytest.approx(26.123)
+
+
+def test_parse_coords_rejects_out_of_bounds():
+    assert ocr_shared.parse_coords("54.0 N, 27.0 E") is None
+    assert ocr_shared.parse_coords("57.0 N, 30.0 E") is None
+
+
+def test_parse_coords_warns_when_over_500_km(monkeypatch, capsys):
+    monkeypatch.setattr(ocr_shared, "_haversine", lambda *args, **kwargs: 600.0)
+
+    result = ocr_shared.parse_coords("58.5 N, 26.0 E")
+
+    captured = capsys.readouterr()
+
+    assert "⚠️" in captured.out
+    assert result == (58.5, 26.0)

--- a/tests/test_salute.py
+++ b/tests/test_salute.py
@@ -1,0 +1,65 @@
+"""Tests for the SALUTE conversation control flow."""
+
+from salute_conversation import SaluteConversation
+
+
+def test_skip_advances_and_clears_answer():
+    convo = SaluteConversation(location_prefill="58T DK 12345 67890")
+
+    assert convo.current_field[0] == "size"
+
+    convo.handle_response("vahele")
+
+    assert convo.answers["size"] == ""
+    assert convo.current_field[0] == "activity"
+
+
+def test_location_prefill_is_preserved_on_skip():
+    prefill = "58T DK 12345 67890"
+    convo = SaluteConversation(location_prefill=prefill)
+
+    assert convo.answers["location"] == prefill
+
+    convo.handle_response("vahele")
+    convo.handle_response("Patrull")
+
+    assert convo.current_field[0] == "location"
+    assert convo.answers["location"] == prefill
+
+    convo.handle_response("vahele")
+
+    assert convo.answers["location"] == prefill
+    assert convo.current_field[0] == "unit"
+
+
+def test_rewind_keyword_moves_back_one_field():
+    convo = SaluteConversation(location_prefill="58T DK 12345 67890")
+
+    convo.handle_response("Väike rühm")
+    convo.handle_response("Valvamas")
+
+    assert convo.current_field[0] == "location"
+
+    convo.handle_response("tagasi")
+
+    assert convo.current_field[0] == "activity"
+
+
+def test_rewind_to_named_field():
+    convo = SaluteConversation(location_prefill="58T DK 12345 67890")
+
+    convo.handle_response("Rühm")
+    convo.handle_response("Patrull")
+    convo.handle_response("vahele")
+    convo.handle_response("Kompanii")
+    convo.handle_response("12:30")
+
+    assert convo.current_field[0] == "equipment"
+
+    convo.handle_response("tagasi aeg")
+
+    assert convo.current_field[0] == "time"
+
+    convo.handle_response("13:00")
+
+    assert convo.answers["time"] == "13:00"


### PR DESCRIPTION
## Summary
- refactor coordinate parsing into a shared module and document development setup
- introduce a reusable `SaluteConversation` helper and update the CLI to use it
- add pytest coverage for SALUTE control flow and OCR parsing edge cases, noting the suite in AGENTS.md

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9c3f0b498832db6401dc409ff0abc