### PR TITLE
Handle missing Tesseract fallback in OCR

### DIFF
--- a/ocr_shared.py
+++ b/ocr_shared.py
@@ -1,0 +1,65 @@
+"""Shared OCR helpers for CLI and tests."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Callable, Optional, Union, Any
+
+import pytesseract
+from PIL import Image
+
+
+ImagePath = Union[str, Path]
+PreprocessFn = Callable[[Image.Image], Image.Image]
+GptFallback = Callable[[ImagePath], str]
+
+
+def _log_warning(logger: Optional[Any], message: str) -> None:
+    if logger is not None and hasattr(logger, "warning"):
+        logger.warning(message)
+    else:
+        print(f"⚠️  {message}", file=sys.stderr)
+
+
+def tesseract_ocr(
+    image_path: ImagePath,
+    *,
+    preprocess: Optional[PreprocessFn] = None,
+    logger: Optional[Any] = None,
+    **kwargs: Any,
+) -> str:
+    """Run Tesseract OCR and return the extracted text."""
+    with Image.open(image_path) as image:
+        processed = preprocess(image) if preprocess else image
+        try:
+            return pytesseract.image_to_string(processed, **kwargs)
+        except pytesseract.pytesseract.TesseractNotFoundError:
+            _log_warning(
+                logger,
+                "Tesseract executable not found; falling back to GPT OCR.",
+            )
+            return ""
+
+
+def run_ocr(
+    image_path: ImagePath,
+    *,
+    preprocess: Optional[PreprocessFn] = None,
+    logger: Optional[Any] = None,
+    gpt_ocr_fn: Optional[GptFallback] = None,
+    **kwargs: Any,
+) -> str:
+    text = tesseract_ocr(
+        image_path,
+        preprocess=preprocess,
+        logger=logger,
+        **kwargs,
+    ).strip()
+
+    if text:
+        return text
+
+    if gpt_ocr_fn is None:
+        return ""
+
+    return gpt_ocr_fn(image_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_ocr_shared.py
+++ b/tests/test_ocr_shared.py
@@ -1,0 +1,25 @@
+import pytesseract
+from PIL import Image
+
+from ocr_shared import run_ocr
+
+
+def test_run_ocr_falls_back_to_gpt_when_tesseract_missing(tmp_path, monkeypatch):
+    image_path = tmp_path / "dummy.png"
+    Image.new("RGB", (2, 2), color="white").save(image_path)
+
+    def raise_not_found(*args, **kwargs):
+        raise pytesseract.pytesseract.TesseractNotFoundError()
+
+    monkeypatch.setattr(pytesseract, "image_to_string", raise_not_found)
+
+    called = {}
+
+    def fake_gpt(path):
+        called["path"] = path
+        return "gpt result"
+
+    result = run_ocr(image_path, gpt_ocr_fn=fake_gpt)
+
+    assert result == "gpt result"
+    assert called["path"] == image_path


### PR DESCRIPTION
## Summary
- add shared OCR helper that catches missing Tesseract errors and logs a warning before deferring to GPT
- ensure `run_ocr` falls back to the GPT handler when Tesseract is unavailable
- cover the regression with a pytest that simulates a missing Tesseract binary

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9c3eae2c0832da317c8183436468e