### PR TITLE
Clarify OCR warning and harden GMT fetch

### DIFF
--- a/multimodal_cli.py
+++ b/multimodal_cli.py
@@ -8,6 +8,7 @@ import logging
 import shutil
 import sys
 from datetime import datetime
+from typing import Any
 
 import requests
 from openai import OpenAI
@@ -25,13 +26,29 @@ def record_and_transcribe(sec: int = 5) -> str:  # noqa: ARG001 - placeholder sh
     return input("[STT] (type response) ")
 
 
+class GmtTimeError(RuntimeError):
+    """Raised when the GMT API returns malformed data."""
+
+
 def fetch_gmt_time() -> str:
     """Return the current GMT timestamp using worldtimeapi.org."""
 
     resp = requests.get("https://worldtimeapi.org/api/timezone/Etc/GMT", timeout=10)
     resp.raise_for_status()
-    payload = resp.json()
-    dt = datetime.fromisoformat(payload["datetime"])
+    try:
+        payload: dict[str, Any] = resp.json()
+    except ValueError as exc:  # json() failed to decode response
+        raise GmtTimeError("Invalid JSON payload from GMT API") from exc
+
+    dt_raw = payload.get("datetime")
+    if not isinstance(dt_raw, str):
+        raise GmtTimeError("GMT API response missing datetime string")
+
+    try:
+        dt = datetime.fromisoformat(dt_raw)
+    except ValueError as exc:
+        raise GmtTimeError("GMT API datetime string was malformed") from exc
+
     return dt.strftime("%Y-%m-%d %H:%M:%S %Z%z")
 
 
@@ -51,7 +68,9 @@ def salute_dialogue(conversation: SaluteConversation) -> None:
 
 def warn_if_missing_tesseract(logger: logging.Logger) -> None:
     if shutil.which("tesseract") is None:
-        logger.warning("Tesseract not in PATH – OCR fallback will fail")
+        logger.warning(
+            "Tesseract not in PATH – using GPT vision fallback (may be slower)"
+        )
 
 
 def build_client(config: AppConfig) -> OpenAI:
@@ -91,7 +110,7 @@ def run_cli(args, config: AppConfig) -> None:
     if args.show_gmt:
         try:
             print(f"[GMT] {fetch_gmt_time()}")
-        except requests.RequestException as exc:
+        except (requests.RequestException, GmtTimeError) as exc:
             logger.warning("GMT fetch failed: %s", exc)
 
     if not args.no_salute:

--- a/ocr_shared.py
+++ b/ocr_shared.py
@@ -13,6 +13,7 @@ from mimetypes import guess_type
 from typing import Callable, Iterable, Optional, Tuple
 
 import pytesseract
+from pytesseract.pytesseract import TesseractNotFoundError
 from PIL import Image, ImageEnhance
 from mgrs import MGRS
 
@@ -126,19 +127,35 @@ def tesseract_ocr(
         return ""
 
     best_txt = ""
-    for angle in angles:
-        txt = pytesseract.image_to_string(
-            preprocess(base.rotate(angle, expand=True)),
-            config=f"--psm {psm} -c tessedit_char_whitelist={whitelist}",
-        ).strip()
+    try:
+        for angle in angles:
+            try:
+                txt = pytesseract.image_to_string(
+                    preprocess(base.rotate(angle, expand=True)),
+                    config=f"--psm {psm} -c tessedit_char_whitelist={whitelist}",
+                ).strip()
+            except TesseractNotFoundError:
+                message = "Tesseract binary not found; skipping to GPT fallback."
+                if logger:
+                    logger.warning(message)
+                else:
+                    print(f"⚠️  {message}", file=sys.stderr)
+                return ""
+            if logger:
+                logger.debug("[Tesseract %d°] %s", angle, txt or "[no text]")
+            else:
+                print(f"\n[Tesseract {angle}°]\n{txt or '[no text]'}")
+            if txt:
+                best_txt = txt
+            if parse_coords(txt, logger=logger, geo=geo):
+                return txt
+    except TesseractNotFoundError:
+        message = "Tesseract binary not found; skipping to GPT fallback."
         if logger:
-            logger.debug("[Tesseract %d°] %s", angle, txt or "[no text]")
+            logger.warning(message)
         else:
-            print(f"\n[Tesseract {angle}°]\n{txt or '[no text]'}")
-        if txt:
-            best_txt = txt
-        if parse_coords(txt, logger=logger, geo=geo):
-            return txt
+            print(f"⚠️  {message}", file=sys.stderr)
+        return ""
     return best_txt
 
 
@@ -193,6 +210,7 @@ def parse_coords(
         lon = float(match_lon.group(1)) * (1 if match_lon.group(2) == "E" else -1)
     else:
         parts = [_strip_dir_suffix(p) for p in re.split(r"[,\s]+", t) if p]
+        parts = [p for p in parts if p]
         if len(parts) < 2:
             return None
         try:

--- a/tests/test_multimodal_cli.py
+++ b/tests/test_multimodal_cli.py
@@ -1,0 +1,91 @@
+"""Tests for CLI helpers including Tesseract warnings and GMT fetching."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import multimodal_cli
+from config import AppConfig
+from ocr_shared import OcrResult
+
+
+class DummyResponse:
+    """Lightweight requests.Response stand-in for testing."""
+
+    def __init__(self, payload=None, *, json_exc: Exception | None = None):
+        self._payload = payload
+        self._json_exc = json_exc
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self):  # type: ignore[no-untyped-def]
+        if self._json_exc:
+            raise self._json_exc
+        return self._payload
+
+
+def test_warn_if_missing_tesseract_mentions_fallback(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Warn about missing Tesseract but reassure users about the GPT fallback."""
+
+    monkeypatch.setattr(multimodal_cli.shutil, "which", lambda _: None)
+
+    logger = logging.getLogger("multimodal_cli.test")
+    with caplog.at_level(logging.WARNING):
+        multimodal_cli.warn_if_missing_tesseract(logger)
+
+    assert "GPT vision fallback" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        DummyResponse(payload={}),
+        DummyResponse(payload={"datetime": 123}),
+        DummyResponse(payload={"datetime": "invalid"}),
+        DummyResponse(json_exc=ValueError("bad json")),
+    ],
+)
+def test_fetch_gmt_time_rejects_malformed_payload(
+    monkeypatch: pytest.MonkeyPatch, response: DummyResponse
+) -> None:
+    """fetch_gmt_time should raise GmtTimeError when payload is malformed."""
+
+    monkeypatch.setattr(multimodal_cli.requests, "get", lambda *_, **__: response)
+
+    with pytest.raises(multimodal_cli.GmtTimeError):
+        multimodal_cli.fetch_gmt_time()
+
+
+def test_run_cli_logs_warning_when_gmt_payload_bad(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """run_cli should catch GmtTimeError and log a warning instead of crashing."""
+
+    args = SimpleNamespace(image="dummy.png", show_gmt=True, no_salute=True)
+    config = AppConfig(openai_api_key="test", telegram_api_token=None)
+
+    ocr_result = OcrResult(lat=59.0, lon=24.0, engine="GPT", raw_text="")
+
+    monkeypatch.setattr(multimodal_cli, "build_client", lambda *_: object())
+    monkeypatch.setattr(multimodal_cli, "run_ocr", lambda *_, **__: ocr_result)
+    def bad_fetch() -> str:
+        raise multimodal_cli.GmtTimeError("bad payload")
+
+    monkeypatch.setattr(multimodal_cli, "fetch_gmt_time", bad_fetch)
+    monkeypatch.setattr(multimodal_cli.shutil, "which", lambda *_: "tesseract")
+
+    with caplog.at_level(logging.WARNING, logger="multimodal_cli"):
+        multimodal_cli.run_cli(args, config)
+
+    assert any("GMT fetch failed" in record.getMessage() for record in caplog.records)

--- a/tests/test_ocr_fallback.py
+++ b/tests/test_ocr_fallback.py
@@ -1,0 +1,44 @@
+"""Tests for OCR fallback behaviour when Tesseract is unavailable."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from PIL import Image
+from pytesseract.pytesseract import TesseractNotFoundError
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import ocr_shared
+
+
+@pytest.fixture()
+def sample_image(tmp_path: Path) -> Path:
+    path = tmp_path / "sample.png"
+    Image.new("RGB", (10, 10), color="white").save(path)
+    return path
+
+
+def test_run_ocr_falls_back_when_tesseract_missing(monkeypatch: pytest.MonkeyPatch, sample_image: Path) -> None:
+    """run_ocr should return GPT results if Tesseract is not installed."""
+
+    def fake_image_to_string(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise TesseractNotFoundError()
+
+    fallback_text = "59.437000° N, 24.753600° E"
+
+    def fake_gpt_vision_ocr(path: str, client, **kwargs):  # type: ignore[no-untyped-def]
+        return fallback_text
+
+    monkeypatch.setattr(ocr_shared.pytesseract, "image_to_string", fake_image_to_string)
+    monkeypatch.setattr(ocr_shared, "gpt_vision_ocr", fake_gpt_vision_ocr)
+
+    result = ocr_shared.run_ocr(str(sample_image), client=object())
+
+    assert result is not None
+    assert result.engine == "GPT-4o-mini Vision"
+    assert result.raw_text == fallback_text
+    assert pytest.approx(result.lat, rel=1e-6) == 59.437
+    assert pytest.approx(result.lon, rel=1e-6) == 24.7536

--- a/tests/test_ocr_shared.py
+++ b/tests/test_ocr_shared.py
@@ -1,0 +1,57 @@
+"""Tests for coordinate parsing helpers used in OCR flows."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from unittest.mock import Mock
+
+import pytest
+
+from config import DEFAULT_GEO_BOUNDS
+from ocr_shared import parse_coords
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        (
+            f"{DEFAULT_GEO_BOUNDS.ref_lat} {DEFAULT_GEO_BOUNDS.ref_lon}",
+            (DEFAULT_GEO_BOUNDS.ref_lat, DEFAULT_GEO_BOUNDS.ref_lon),
+        ),
+        (
+            f"{DEFAULT_GEO_BOUNDS.lon_min + 1.5} {DEFAULT_GEO_BOUNDS.lat_max - 1.0}",
+            (DEFAULT_GEO_BOUNDS.lat_max - 1.0, DEFAULT_GEO_BOUNDS.lon_min + 1.5),
+        ),
+        (
+            f"{DEFAULT_GEO_BOUNDS.ref_lat} N {DEFAULT_GEO_BOUNDS.ref_lon} E",
+            (DEFAULT_GEO_BOUNDS.ref_lat, DEFAULT_GEO_BOUNDS.ref_lon),
+        ),
+    ],
+)
+def test_parse_coords_success_cases(text: str, expected: tuple[float, float]) -> None:
+    """parse_coords should accept normal, swapped, and suffixed values."""
+
+    result = parse_coords(text, geo=DEFAULT_GEO_BOUNDS)
+    assert result == pytest.approx(expected)  # type: ignore[arg-type]
+
+
+def test_parse_coords_returns_none_when_out_of_bounds() -> None:
+    """Values outside the configured bounds should be rejected."""
+
+    text = f"{DEFAULT_GEO_BOUNDS.lat_max + 1.0} {DEFAULT_GEO_BOUNDS.lon_max + 1.0}"
+    assert parse_coords(text, geo=DEFAULT_GEO_BOUNDS) is None
+
+
+def test_parse_coords_logs_warning_when_far_from_reference() -> None:
+    """Coordinates beyond the allowed radius emit a warning."""
+
+    shrunk_bounds = replace(DEFAULT_GEO_BOUNDS, radius_km=100.0)
+    logger = Mock()
+    text = f"{DEFAULT_GEO_BOUNDS.lat_min} {DEFAULT_GEO_BOUNDS.lon_min}"
+
+    result = parse_coords(text, logger=logger, geo=shrunk_bounds)
+
+    assert result == pytest.approx(
+        (DEFAULT_GEO_BOUNDS.lat_min, DEFAULT_GEO_BOUNDS.lon_min)
+    )  # type: ignore[arg-type]
+    logger.warning.assert_called_once()

--- a/tests/test_salute.py
+++ b/tests/test_salute.py
@@ -1,0 +1,123 @@
+"""Tests covering SALUTE conversation skip and rewind flows."""
+
+from __future__ import annotations
+
+import pytest
+
+from salute import SaluteConversation, SaluteStepResult
+
+
+@pytest.fixture()
+def conversation() -> SaluteConversation:
+    """Return a fresh conversation using the default SALUTE fields."""
+
+    return SaluteConversation()
+
+
+def complete(conversation: SaluteConversation, *answers: str) -> SaluteStepResult:
+    """Feed answers sequentially and return the last step result."""
+
+    result: SaluteStepResult | None = None
+    for answer in answers:
+        result = conversation.handle(answer)
+    assert result is not None
+    return result
+
+
+def test_vahele_skips_current_field(conversation: SaluteConversation) -> None:
+    """"vahele" leaves the current field empty and advances."""
+
+    result = conversation.handle("vahele")
+
+    expected_prompt = (
+        f"Palun ütle {conversation.fields[1].label}. (või 'vahele'/'tagasi')"
+    )
+    assert not result.completed
+    assert result.prompt == expected_prompt
+
+    final = complete(
+        conversation,
+        "Vaadeldav tegevus",
+        "Sihtasukoht",
+        "Üksus",
+        "Ajahetk",
+        "Varustus",
+    )
+
+    assert final.completed
+    assert final.report_lines is not None
+    assert final.report_lines[0] == "Suurus: –"
+
+
+def test_tagasi_with_target_rewinds_to_field(conversation: SaluteConversation) -> None:
+    """Targeted tagasi rewinds to the requested field prompt."""
+
+    complete(conversation, "Esialgne suurus", "Esialgne tegevus")
+    result = conversation.handle("tagasi tegevus")
+
+    expected_prompt = (
+        f"Palun ütle {conversation.fields[1].label}. (või 'vahele'/'tagasi')"
+    )
+    assert not result.completed
+    assert result.prompt == expected_prompt
+
+    final = complete(
+        conversation,
+        "Uuendatud tegevus",
+        "Täpsustatud asukoht",
+        "Üksus",
+        "Ajahetk",
+        "Varustus",
+    )
+
+    assert final.completed
+    assert final.report_lines is not None
+    assert final.report_lines[1] == "Tegevus: Uuendatud tegevus"
+    assert final.report_lines[2] == "Asukoht: Täpsustatud asukoht"
+
+
+def test_tagasi_without_target_rewinds_previous(conversation: SaluteConversation) -> None:
+    """Plain tagasi rewinds to the immediate previous field."""
+
+    conversation.handle("Algne suurus")
+    result = conversation.handle("tagasi")
+
+    expected_prompt = (
+        f"Palun ütle {conversation.fields[0].label}. (või 'vahele'/'tagasi')"
+    )
+    assert not result.completed
+    assert result.prompt == expected_prompt
+
+    final = complete(
+        conversation,
+        "Uuendatud suurus",
+        "Tegevus",
+        "Asukoht",
+        "Üksus",
+        "Aeg",
+        "Varustus",
+    )
+
+    assert final.completed
+    assert final.report_lines is not None
+    assert final.report_lines[0] == "Suurus: Uuendatud suurus"
+
+
+def test_constructor_location_prefills_report() -> None:
+    """Providing location to the constructor should pre-populate the report line."""
+
+    conversation = SaluteConversation(location="34VEM12345678")
+
+    final = complete(
+        conversation,
+        "Suurus",
+        "Tegevus",
+        "Asukoht käsitsi",
+        "Üksus",
+        "Aeg",
+        "Varustus",
+    )
+
+    assert final.completed
+    assert final.report_lines is not None
+    assert final.report_lines[2] == "Asukoht: Asukoht käsitsi"


### PR DESCRIPTION
## Summary
- update the CLI Tesseract warning to mention the GPT fallback path and add a dedicated GMT error type
- harden `fetch_gmt_time` against malformed JSON/datetime payloads and catch the new error alongside `RequestException`
- add CLI-focused regression tests covering the warning copy, GMT error propagation, and logging behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9c5fff738832d976457dd799884bc