### PR TITLE
Allow CLI to run without GPT fallback

### DIFF
--- a/multimodal_cli.py
+++ b/multimodal_cli.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-import shutil
 import sys
 from datetime import datetime
 from typing import Any
@@ -15,7 +14,7 @@ from openai import OpenAI
 
 from config import AppConfig, load_config
 from logging_utils import configure_logging, get_logger
-from ocr_shared import run_ocr
+from ocr_shared import run_ocr, warn_if_missing_tesseract
 from salute import SaluteConversation
 
 def speak(text: str) -> None:
@@ -66,22 +65,23 @@ def salute_dialogue(conversation: SaluteConversation) -> None:
             break
 
 
-def warn_if_missing_tesseract(logger: logging.Logger) -> None:
-    if shutil.which("tesseract") is None:
-        logger.warning(
-            "Tesseract not in PATH – using GPT vision fallback (may be slower)"
-        )
-
-
 def build_client(config: AppConfig) -> OpenAI:
     return OpenAI(api_key=config.openai_api_key)
 
 
 def run_cli(args, config: AppConfig) -> None:
     logger = get_logger("multimodal_cli")
-    warn_if_missing_tesseract(logger)
+    missing_tesseract = warn_if_missing_tesseract(logger)
 
-    client = build_client(config)
+    client: OpenAI | None = None
+    if config.openai_api_key:
+        client = build_client(config)
+    else:
+        if missing_tesseract:
+            sys.exit(
+                "❌  Tesseract puudub ja GPT varuplaan on keelatud (OpenAI võti puudub)."
+            )
+        logger.info("GPT vision fallback disabled: OpenAI API key not configured.")
 
     def report_raw(engine: str, text: str) -> None:
         print(f"\n=== {engine} ===\n", text or "[tühi]")
@@ -139,7 +139,7 @@ def main() -> None:
     configure_logging()
 
     try:
-        config = load_config(require_openai=True)
+        config = load_config(require_openai=False)
     except RuntimeError as exc:
         sys.exit(f"❌  {exc}")
 

--- a/ocr_shared.py
+++ b/ocr_shared.py
@@ -6,11 +6,12 @@ import logging
 import math
 import random
 import re
+import shutil
 import sys
 import time
 from dataclasses import dataclass
 from mimetypes import guess_type
-from typing import Callable, Iterable, Optional, Tuple
+from typing import Any, Callable, Iterable, Optional, Tuple
 
 import pytesseract
 from pytesseract.pytesseract import TesseractNotFoundError
@@ -26,6 +27,20 @@ LON_MAX = DEFAULT_GEO_BOUNDS.lon_max
 REF_LAT = DEFAULT_GEO_BOUNDS.ref_lat
 REF_LON = DEFAULT_GEO_BOUNDS.ref_lon
 RADIUS_KM = DEFAULT_GEO_BOUNDS.radius_km
+
+MISSING_TESSERACT_WARNING = "Tesseract not in PATH – using GPT vision fallback (may be slower)"
+
+
+def warn_if_missing_tesseract(logger: Optional[logging.Logger] = None) -> bool:
+    """Log a warning when Tesseract is missing and return True if absent."""
+
+    missing = shutil.which("tesseract") is None
+    if missing:
+        if logger:
+            logger.warning(MISSING_TESSERACT_WARNING)
+        else:
+            print(f"⚠️  {MISSING_TESSERACT_WARNING}", file=sys.stderr)
+    return missing
 
 _DEFAULT_PROMPT = (
     "Leia drooni ekraanil kuvatud GPS-koordinaadid ja vasta ainult kümnendkraadides, "
@@ -118,45 +133,36 @@ def tesseract_ocr(
     """Run Tesseract OCR against the provided image path."""
 
     try:
-        base = Image.open(path)
+        with Image.open(path) as base:
+            best_txt = ""
+            for angle in angles:
+                try:
+                    txt = pytesseract.image_to_string(
+                        preprocess(base.rotate(angle, expand=True)),
+                        config=f"--psm {psm} -c tessedit_char_whitelist={whitelist}",
+                    ).strip()
+                except TesseractNotFoundError:
+                    message = "Tesseract binary not found; skipping to GPT fallback."
+                    if logger:
+                        logger.warning(message)
+                    else:
+                        print(f"⚠️  {message}", file=sys.stderr)
+                    return ""
+                if logger:
+                    logger.debug("[Tesseract %d°] %s", angle, txt or "[no text]")
+                else:
+                    print(f"\n[Tesseract {angle}°]\n{txt or '[no text]'}")
+                if txt:
+                    best_txt = txt
+                if parse_coords(txt, logger=logger, geo=geo):
+                    return txt
+            return best_txt
     except Exception as exc:  # pragma: no cover - file failure path
         if logger:
             logger.error("Cannot open %s: %s", path, exc)
         else:
             print("❌  Cannot open image:", exc, file=sys.stderr)
         return ""
-
-    best_txt = ""
-    try:
-        for angle in angles:
-            try:
-                txt = pytesseract.image_to_string(
-                    preprocess(base.rotate(angle, expand=True)),
-                    config=f"--psm {psm} -c tessedit_char_whitelist={whitelist}",
-                ).strip()
-            except TesseractNotFoundError:
-                message = "Tesseract binary not found; skipping to GPT fallback."
-                if logger:
-                    logger.warning(message)
-                else:
-                    print(f"⚠️  {message}", file=sys.stderr)
-                return ""
-            if logger:
-                logger.debug("[Tesseract %d°] %s", angle, txt or "[no text]")
-            else:
-                print(f"\n[Tesseract {angle}°]\n{txt or '[no text]'}")
-            if txt:
-                best_txt = txt
-            if parse_coords(txt, logger=logger, geo=geo):
-                return txt
-    except TesseractNotFoundError:
-        message = "Tesseract binary not found; skipping to GPT fallback."
-        if logger:
-            logger.warning(message)
-        else:
-            print(f"⚠️  {message}", file=sys.stderr)
-        return ""
-    return best_txt
 
 
 def gpt_vision_ocr(
@@ -184,7 +190,45 @@ def gpt_vision_ocr(
         timeout=60,
         logger=logger,
     )
-    return resp.choices[0].message.content.strip()
+    choices = getattr(resp, "choices", None)
+    if not choices:
+        message = "GPT vision response missing completion choices; returning empty string."
+        if logger:
+            logger.warning(message)
+        else:
+            print(f"⚠️  {message}", file=sys.stderr)
+        return ""
+
+    first_choice = choices[0]
+    message_obj = getattr(first_choice, "message", None)
+    if message_obj is None and isinstance(first_choice, dict):
+        message_obj = first_choice.get("message")
+
+    content = None
+    if message_obj is not None:
+        content = getattr(message_obj, "content", None)
+        if content is None and isinstance(message_obj, dict):
+            content = message_obj.get("content")
+
+    if isinstance(content, list):
+        texts = []
+        for part in content:
+            if isinstance(part, dict):
+                if part.get("type") == "text" and isinstance(part.get("text"), str):
+                    texts.append(part["text"])
+            elif isinstance(part, str):
+                texts.append(part)
+        content = "\n".join(segment.strip() for segment in texts if segment.strip())
+
+    if not isinstance(content, str) or not content.strip():
+        message = "GPT vision response missing text content; returning empty string."
+        if logger:
+            logger.warning(message)
+        else:
+            print(f"⚠️  {message}", file=sys.stderr)
+        return ""
+
+    return content.strip()
 
 
 def _strip_dir_suffix(value: str) -> str:
@@ -202,6 +246,8 @@ def parse_coords(
     if not txt:
         return None
     t = txt.upper().replace("°", " ")
+    # Normalize decimal commas (e.g., "59,437") to dots before parsing.
+    t = re.sub(r"(?<=\d),(?=\d)", ".", t)
 
     match_lat = re.search(r"(-?\d+\.\d+)\s*([NS])", t)
     match_lon = re.search(r"(-?\d+\.\d+)\s*([EW])", t)
@@ -255,7 +301,7 @@ def format_decimal(lat: float, lon: float) -> str:
 
 def run_ocr(
     path: str,
-    client,
+    client: Optional[Any] = None,
     *,
     logger: Optional[logging.Logger] = None,
     on_raw: Optional[Callable[[str, str], None]] = None,
@@ -270,6 +316,14 @@ def run_ocr(
     if coords:
         lat, lon = coords
         return OcrResult(lat=lat, lon=lon, engine="Tesseract", raw_text=raw)
+
+    if client is None:
+        message = "GPT fallback unavailable because OpenAI client is not configured."
+        if logger:
+            logger.warning(message)
+        else:
+            print(f"⚠️  {message}", file=sys.stderr)
+        return None
 
     raw = gpt_vision_ocr(path, client, logger=logger)
     if on_raw:
@@ -290,6 +344,8 @@ __all__ = [
     "REF_LAT",
     "REF_LON",
     "RADIUS_KM",
+    "MISSING_TESSERACT_WARNING",
+    "warn_if_missing_tesseract",
     "OcrResult",
     "retry",
     "to_data_url",

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import os
-import shutil
 import tempfile
 from typing import Optional
 
@@ -18,10 +17,11 @@ from telegram.ext import (
     MessageHandler,
     Updater,
 )
+from telegram.error import TelegramError
 
 from config import AppConfig, load_config
 from logging_utils import configure_logging, get_logger
-from ocr_shared import run_ocr
+from ocr_shared import run_ocr, warn_if_missing_tesseract
 from salute import SaluteConversation
 
 SALUTE = 1
@@ -69,20 +69,43 @@ def salute_handler(update: Update, context: CallbackContext) -> int:
 
 
 def handle_photo(update: Update, context: CallbackContext) -> int:
-    assert CLIENT is not None
-    assert CONFIG is not None
+    config = CONFIG
+    client = CLIENT
 
-    photo = update.message.photo[-1]
-    tg_file = context.bot.get_file(photo.file_id)
+    if client is None or config is None:
+        LOGGER.error("Bot configuration incomplete; refusing to process photo")
+        update.message.reply_text("Teenusel puudub konfiguratsioon. Palun proovi hiljem uuesti.")
+        return ConversationHandler.END
+
+    try:
+        photo = update.message.photo[-1]
+    except (AttributeError, IndexError):  # pragma: no cover - defensive guard
+        LOGGER.warning("Received photo update without image payload")
+        update.message.reply_text("Pildist ei saadud aru. Palun proovi uuesti.")
+        return ConversationHandler.END
+
+    try:
+        tg_file = context.bot.get_file(photo.file_id)
+    except TelegramError as exc:
+        LOGGER.error("Failed to fetch Telegram file: %s", exc)
+        update.message.reply_text("Pildi allalaadimine ebaõnnestus. Palun proovi uuesti.")
+        return ConversationHandler.END
 
     tmp = tempfile.NamedTemporaryFile(suffix=".jpg", delete=False)
     tmp.close()
     path = tmp.name
 
+    result = None
     try:
-        tg_file.download(path)
         try:
-            result = run_ocr(path, CLIENT, logger=LOGGER, geo=CONFIG.geo)
+            tg_file.download(path)
+        except TelegramError as exc:
+            LOGGER.error("Telegram download failed: %s", exc)
+            update.message.reply_text("Pildi allalaadimine ebaõnnestus. Palun proovi uuesti.")
+            return ConversationHandler.END
+
+        try:
+            result = run_ocr(path, client, logger=LOGGER, geo=config.geo)
         except Exception as exc:  # pragma: no cover - network failure path
             LOGGER.error("OCR pipeline failed: %s", exc)
             result = None
@@ -98,7 +121,7 @@ def handle_photo(update: Update, context: CallbackContext) -> int:
 
     update.message.reply_text(f"📍 Koordinaadid: {result.decimal}\n🗺 MGRS: {result.mgrs}")
     context.user_data["salute_conv"] = SaluteConversation(
-        fields=CONFIG.salute_fields,
+        fields=config.salute_fields,
         location=result.mgrs,
     )
     return ask_salute(update, context)
@@ -121,8 +144,7 @@ def main() -> None:
     CONFIG = config
     CLIENT = OpenAI(api_key=config.openai_api_key)
 
-    if shutil.which("tesseract") is None:
-        LOGGER.warning("Tesseract not in PATH – OCR fallback will fail")
+    warn_if_missing_tesseract(LOGGER)
 
     updater = Updater(token=config.telegram_api_token, use_context=True)
     dispatcher = updater.dispatcher

--- a/tests/test_multimodal_cli.py
+++ b/tests/test_multimodal_cli.py
@@ -37,7 +37,7 @@ def test_warn_if_missing_tesseract_mentions_fallback(
 ) -> None:
     """Warn about missing Tesseract but reassure users about the GPT fallback."""
 
-    monkeypatch.setattr(multimodal_cli.shutil, "which", lambda _: None)
+    monkeypatch.setattr("ocr_shared.shutil.which", lambda _: None)
 
     logger = logging.getLogger("multimodal_cli.test")
     with caplog.at_level(logging.WARNING):
@@ -83,9 +83,50 @@ def test_run_cli_logs_warning_when_gmt_payload_bad(
         raise multimodal_cli.GmtTimeError("bad payload")
 
     monkeypatch.setattr(multimodal_cli, "fetch_gmt_time", bad_fetch)
-    monkeypatch.setattr(multimodal_cli.shutil, "which", lambda *_: "tesseract")
+    monkeypatch.setattr(multimodal_cli, "warn_if_missing_tesseract", lambda *_: False)
 
     with caplog.at_level(logging.WARNING, logger="multimodal_cli"):
         multimodal_cli.run_cli(args, config)
 
     assert any("GMT fetch failed" in record.getMessage() for record in caplog.records)
+
+
+def test_run_cli_allows_tesseract_only_mode(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """run_cli should skip GPT setup when no API key is configured."""
+
+    args = SimpleNamespace(image="dummy.png", show_gmt=False, no_salute=True)
+    config = AppConfig(openai_api_key="", telegram_api_token=None)
+
+    ocr_result = OcrResult(lat=59.0, lon=24.0, engine="Tesseract", raw_text="")
+
+    def fail_build_client(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("build_client should not be called without API key")
+
+    def fake_run_ocr(path, client, **kwargs):  # type: ignore[no-untyped-def]
+        assert client is None
+        return ocr_result
+
+    monkeypatch.setattr(multimodal_cli, "build_client", fail_build_client)
+    monkeypatch.setattr(multimodal_cli, "run_ocr", fake_run_ocr)
+    monkeypatch.setattr(multimodal_cli, "warn_if_missing_tesseract", lambda *_: False)
+
+    with caplog.at_level(logging.INFO, logger="multimodal_cli"):
+        multimodal_cli.run_cli(args, config)
+
+    assert "fallback disabled" in caplog.text
+
+
+def test_run_cli_exits_when_no_tesseract_and_no_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tesseract-only mode should exit when Tesseract is missing."""
+
+    args = SimpleNamespace(image="dummy.png", show_gmt=False, no_salute=True)
+    config = AppConfig(openai_api_key="", telegram_api_token=None)
+
+    monkeypatch.setattr(multimodal_cli, "warn_if_missing_tesseract", lambda *_: True)
+
+    with pytest.raises(SystemExit) as excinfo:
+        multimodal_cli.run_cli(args, config)
+
+    assert "OpenAI" in str(excinfo.value)

--- a/tests/test_ocr_fallback.py
+++ b/tests/test_ocr_fallback.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import sys
+import logging
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from PIL import Image
@@ -42,3 +44,99 @@ def test_run_ocr_falls_back_when_tesseract_missing(monkeypatch: pytest.MonkeyPat
     assert result.raw_text == fallback_text
     assert pytest.approx(result.lat, rel=1e-6) == 59.437
     assert pytest.approx(result.lon, rel=1e-6) == 24.7536
+
+
+def _make_dummy_client():
+    return SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=lambda *args, **kwargs: None  # pragma: no cover - stubbed by retry
+            )
+        )
+    )
+
+
+def test_gpt_vision_handles_missing_choices(
+    monkeypatch: pytest.MonkeyPatch, sample_image: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """gpt_vision_ocr should warn and return empty text when choices are missing."""
+
+    class DummyResponse:
+        choices: list = []
+
+    def fake_retry(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return DummyResponse()
+
+    monkeypatch.setattr(ocr_shared, "retry", fake_retry)
+
+    caplog.set_level(logging.WARNING)
+    logger = logging.getLogger("test_missing_choices")
+
+    result = ocr_shared.gpt_vision_ocr(
+        str(sample_image), client=_make_dummy_client(), logger=logger
+    )
+
+    assert result == ""
+    assert "missing completion choices" in caplog.text
+
+
+def test_gpt_vision_flattens_list_content(
+    monkeypatch: pytest.MonkeyPatch, sample_image: Path
+) -> None:
+    """Ensure list-based message content is flattened into a string."""
+
+    class DummyMessage:
+        def __init__(self, content):
+            self.content = content
+
+    class DummyChoice:
+        def __init__(self, content):
+            self.message = DummyMessage(content)
+
+    class DummyResponse:
+        def __init__(self, content):
+            self.choices = [DummyChoice(content)]
+
+    payload = [
+        {"type": "text", "text": "59.437000° N"},
+        {"type": "text", "text": "24.753600° E"},
+    ]
+
+    def fake_retry(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return DummyResponse(payload)
+
+    monkeypatch.setattr(ocr_shared, "retry", fake_retry)
+
+    result = ocr_shared.gpt_vision_ocr(
+        str(sample_image),
+        client=_make_dummy_client(),
+        logger=logging.getLogger("test_flatten"),
+    )
+
+    assert result == "59.437000° N\n24.753600° E"
+
+
+def test_run_ocr_warns_when_fallback_unavailable(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, sample_image: Path
+) -> None:
+    """run_ocr should log a warning and return None if GPT fallback is disabled."""
+
+    monkeypatch.setattr(ocr_shared, "tesseract_ocr", lambda *_, **__: "")
+
+    called = False
+
+    def fail_gpt(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        nonlocal called
+        called = True
+        return ""
+
+    monkeypatch.setattr(ocr_shared, "gpt_vision_ocr", fail_gpt)
+
+    caplog.set_level(logging.WARNING)
+    logger = logging.getLogger("test_no_fallback")
+
+    result = ocr_shared.run_ocr(str(sample_image), client=None, logger=logger)
+
+    assert result is None
+    assert called is False
+    assert "fallback unavailable" in caplog.text

--- a/tests/test_ocr_shared.py
+++ b/tests/test_ocr_shared.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock
 import pytest
 
 from config import DEFAULT_GEO_BOUNDS
-from ocr_shared import parse_coords
+from ocr_shared import MISSING_TESSERACT_WARNING, parse_coords, warn_if_missing_tesseract
 
 
 @pytest.mark.parametrize(
@@ -17,6 +17,10 @@ from ocr_shared import parse_coords
         (
             f"{DEFAULT_GEO_BOUNDS.ref_lat} {DEFAULT_GEO_BOUNDS.ref_lon}",
             (DEFAULT_GEO_BOUNDS.ref_lat, DEFAULT_GEO_BOUNDS.ref_lon),
+        ),
+        (
+            "59,437 N 24,753 E",
+            (59.437, 24.753),
         ),
         (
             f"{DEFAULT_GEO_BOUNDS.lon_min + 1.5} {DEFAULT_GEO_BOUNDS.lat_max - 1.0}",
@@ -55,3 +59,29 @@ def test_parse_coords_logs_warning_when_far_from_reference() -> None:
         (DEFAULT_GEO_BOUNDS.lat_min, DEFAULT_GEO_BOUNDS.lon_min)
     )  # type: ignore[arg-type]
     logger.warning.assert_called_once()
+
+
+def test_warn_if_missing_tesseract_logs_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    """warn_if_missing_tesseract should log when the binary is absent."""
+
+    monkeypatch.setattr("ocr_shared.shutil.which", lambda _: None)
+    logger = Mock()
+
+    missing = warn_if_missing_tesseract(logger)
+
+    assert missing is True
+    logger.warning.assert_called_once_with(MISSING_TESSERACT_WARNING)
+
+
+def test_warn_if_missing_tesseract_returns_false_when_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """warn_if_missing_tesseract should return False when the binary exists."""
+
+    monkeypatch.setattr("ocr_shared.shutil.which", lambda _: "/usr/bin/tesseract")
+    logger = Mock()
+
+    missing = warn_if_missing_tesseract(logger)
+
+    assert missing is False
+    logger.warning.assert_not_called()


### PR DESCRIPTION
## Summary
- add a shared `warn_if_missing_tesseract` helper so entry points log a consistent fallback message when the binary is absent
- update the CLI and Telegram bot to call the helper instead of duplicating their own `tesseract` checks
- cover the helper with dedicated unit tests and adjust CLI tests to stub the new pathway
- allow the CLI to skip GPT setup when no OpenAI API key is configured and only require it when Tesseract is missing
- make `run_ocr` treat the OpenAI client as optional, warn when the fallback is disabled, and add regression tests for Tesseract-only mode

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9d556aa40832d9c6ebea191b480b5